### PR TITLE
feat(smtr/dbt): adiciona logs do `dbt` 🔍 + ajusta comandos nos flows de materialização de `gps`

### DIFF
--- a/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
@@ -28,7 +28,7 @@ from pipelines.rj_smtr.tasks import (
     get_materialization_date_range,
     # get_local_dbt_client,
     get_raw,
-    run_dbt_command,
+    run_dbt_model,
     save_raw_local,
     save_treated_local,
     set_last_run_timestamp,
@@ -77,24 +77,22 @@ with Flow(
 
     # Run materialization #
     with case(rebuild, True):
-        RUN = run_dbt_command(
+        RUN = run_dbt_model(
             dbt_client=dbt_client,
-            table_id=table_id,
-            command="run",
+            model=table_id,
+            upstream=True,
             exclude="+data_versao_efetiva",
             _vars=[date_range, dataset_sha],
-            upstream=True,
             flags="--full-refresh",
         )
         set_last_run_timestamp(dataset_id=dataset_id, table_id=table_id, wait=RUN)
     with case(rebuild, False):
-        RUN = run_dbt_command(
+        RUN = run_dbt_model(
             dbt_client=dbt_client,
-            table_id=table_id,
-            command="run",
+            model=table_id,
+            upstream=True,
             exclude="+data_versao_efetiva",
             _vars=[date_range, dataset_sha],
-            upstream=True,
         )
         set_last_run_timestamp(dataset_id=dataset_id, table_id=table_id, wait=RUN)
 

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
@@ -48,11 +48,14 @@ with Flow(
 ) as materialize_brt:
 
     # Get default parameters #
-    dataset_id = Parameter("dataset_id", default=constants.GPS_BRT_DATASET_ID.value)
-    table_id = Parameter("table_id", default=constants.GPS_BRT_TREATED_TABLE_ID.value)
+    raw_dataset_id = Parameter(
+        "raw_dataset_id", default=constants.GPS_BRT_RAW_DATASET_ID.value
+    )
     raw_table_id = Parameter(
         "raw_table_id", default=constants.GPS_BRT_RAW_TABLE_ID.value
     )
+    dataset_id = Parameter("dataset_id", default=constants.GPS_BRT_DATASET_ID.value)
+    table_id = Parameter("table_id", default=constants.GPS_BRT_TREATED_TABLE_ID.value)
     rebuild = Parameter("rebuild", False)
 
     # Set dbt client #
@@ -64,6 +67,7 @@ with Flow(
     date_range = get_materialization_date_range(
         dataset_id=dataset_id,
         table_id=table_id,
+        raw_dataset_id=raw_dataset_id,
         raw_table_id=raw_table_id,
         table_date_column_name="data",
     )
@@ -75,24 +79,22 @@ with Flow(
     with case(rebuild, True):
         RUN = run_dbt_command(
             dbt_client=dbt_client,
-            dataset_id=dataset_id,
             table_id=table_id,
             command="run",
+            exclude="+data_versao_efetiva",
             _vars=[date_range, dataset_sha],
             upstream=True,
-            downstream=True,
             flags="--full-refresh",
         )
         set_last_run_timestamp(dataset_id=dataset_id, table_id=table_id, wait=RUN)
     with case(rebuild, False):
         RUN = run_dbt_command(
             dbt_client=dbt_client,
-            dataset_id=dataset_id,
             table_id=table_id,
             command="run",
+            exclude="+data_versao_efetiva",
             _vars=[date_range, dataset_sha],
             upstream=True,
-            downstream=True,
         )
         set_last_run_timestamp(dataset_id=dataset_id, table_id=table_id, wait=RUN)
 

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -28,7 +28,7 @@ from pipelines.rj_smtr.tasks import (
     get_materialization_date_range,
     # get_local_dbt_client,
     get_raw,
-    run_dbt_command,
+    run_dbt_model,
     save_raw_local,
     save_treated_local,
     set_last_run_timestamp,
@@ -76,21 +76,19 @@ with Flow(
 
     # Run materialization #
     with case(rebuild, True):
-        RUN = run_dbt_command(
+        RUN = run_dbt_model(
             dbt_client=dbt_client,
-            table_id=table_id,
-            command="run",
+            model=table_id,
+            upstream=True,
             exclude="+data_versao_efetiva",
             _vars=[date_range, dataset_sha],
-            upstream=True,
             flags="--full-refresh",
         )
         set_last_run_timestamp(dataset_id=dataset_id, table_id=table_id, wait=RUN)
     with case(rebuild, False):
-        RUN = run_dbt_command(
+        RUN = run_dbt_model(
             dbt_client=dbt_client,
-            table_id=table_id,
-            command="run",
+            model=table_id,
             exclude="+data_versao_efetiva",
             _vars=[date_range, dataset_sha],
             upstream=True,

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -47,11 +47,14 @@ with Flow(
 ) as materialize_sppo:
 
     # Get default parameters #
-    dataset_id = Parameter("dataset_id", default=constants.GPS_SPPO_DATASET_ID.value)
-    table_id = Parameter("table_id", default=constants.GPS_SPPO_TREATED_TABLE_ID.value)
+    raw_dataset_id = Parameter(
+        "raw_dataset_id", default=constants.GPS_SPPO_RAW_DATASET_ID.value
+    )
     raw_table_id = Parameter(
         "raw_table_id", default=constants.GPS_SPPO_RAW_TABLE_ID.value
     )
+    dataset_id = Parameter("dataset_id", default=constants.GPS_SPPO_DATASET_ID.value)
+    table_id = Parameter("table_id", default=constants.GPS_SPPO_TREATED_TABLE_ID.value)
     rebuild = Parameter("rebuild", False)
 
     # Set dbt client #
@@ -63,6 +66,7 @@ with Flow(
     date_range = get_materialization_date_range(
         dataset_id=dataset_id,
         table_id=table_id,
+        raw_dataset_id=raw_dataset_id,
         raw_table_id=raw_table_id,
         table_date_column_name="data",
     )
@@ -74,24 +78,22 @@ with Flow(
     with case(rebuild, True):
         RUN = run_dbt_command(
             dbt_client=dbt_client,
-            dataset_id=dataset_id,
             table_id=table_id,
             command="run",
+            exclude="+data_versao_efetiva",
             _vars=[date_range, dataset_sha],
             upstream=True,
-            downstream=True,
             flags="--full-refresh",
         )
         set_last_run_timestamp(dataset_id=dataset_id, table_id=table_id, wait=RUN)
     with case(rebuild, False):
         RUN = run_dbt_command(
             dbt_client=dbt_client,
-            dataset_id=dataset_id,
             table_id=table_id,
             command="run",
+            exclude="+data_versao_efetiva",
             _vars=[date_range, dataset_sha],
             upstream=True,
-            downstream=True,
         )
         set_last_run_timestamp(dataset_id=dataset_id, table_id=table_id, wait=RUN)
 

--- a/pipelines/rj_smtr/constants.py
+++ b/pipelines/rj_smtr/constants.py
@@ -36,9 +36,10 @@ class constants(Enum):  # pylint: disable=c0103
     )
     GPS_SPPO_API_SECRET_PATH = "sppo_api"
 
-    GPS_SPPO_DATASET_ID = "br_rj_riodejaneiro_onibus_gps"
+    GPS_SPPO_RAW_DATASET_ID = "br_rj_riodejaneiro_onibus_gps"
     GPS_SPPO_RAW_TABLE_ID = "registros"
-    GPS_SPPO_TREATED_TABLE_ID = "sppo_aux_registros_filtrada"
+    GPS_SPPO_DATASET_ID = "br_rj_riodejaneiro_veiculos"
+    GPS_SPPO_TREATED_TABLE_ID = "gps_sppo"
 
     # GPS BRT #
     GPS_BRT_API_BASE_URL = (
@@ -46,9 +47,10 @@ class constants(Enum):  # pylint: disable=c0103
     )
     # GPS_BRT_API_SECRET_PATH = "sppo_api"
 
-    GPS_BRT_DATASET_ID = "br_rj_riodejaneiro_brt_gps"
+    GPS_BRT_DATASET_ID = "br_rj_riodejaneiro_veiculos"
+    GPS_BRT_RAW_DATASET_ID = "br_rj_riodejaneiro_brt_gps"
     GPS_BRT_RAW_TABLE_ID = "registros"
-    GPS_BRT_TREATED_TABLE_ID = "brt_aux_registros_filtrada"
+    GPS_BRT_TREATED_TABLE_ID = "gps_brt"
 
     # SIGMOB (GTFS) #
     SIGMOB_GET_REQUESTS_TIMEOUT = 60

--- a/pipelines/rj_smtr/utils.py
+++ b/pipelines/rj_smtr/utils.py
@@ -34,6 +34,24 @@ def log_critical(message: str, secret_path: str = constants.CRITICAL_SECRET_PATH
     return send_discord_message(message=message, webhook_url=url)
 
 
+def parse_dbt_logs(logs_dict: dict, log_queries: bool = False):
+    """Parse dbt returned logs, to print only needed
+    pieces.
+
+    Args:
+        logs_dict (dict): logs dict returned when running a DBT
+        command via DbtClient.cli() with argument logs = True
+    """
+    for event in logs_dict["result"]["logs"]:
+        if event["levelname"] == "INFO" or event["levelname"] == "ERROR":
+            log(f"#####{event['levelname']}#####")
+            log(event["message"])
+        if event["levelname"] == "DEBUG" and log_queries:
+            if "On model" in event["message"]:
+                log(event["message"])
+    return None
+
+
 def create_or_append_table(dataset_id, table_id, path):
     """Conditionally create table or append data to its relative GCS folder.
 

--- a/pipelines/rj_smtr/utils.py
+++ b/pipelines/rj_smtr/utils.py
@@ -49,7 +49,6 @@ def parse_dbt_logs(logs_dict: dict, log_queries: bool = False):
         if event["levelname"] == "DEBUG" and log_queries:
             if "On model" in event["message"]:
                 log(event["message"])
-    return None
 
 
 def create_or_append_table(dataset_id, table_id, path):


### PR DESCRIPTION
Descrição:
- Adiciona `parse_dbt_logs` em `rj_smtr/utils.py`: função para filtrar somente os logs necessários a partir do `dict` retornado após rodar o comando do dbt via task `run_dbt_command`
- Ajusta os comandos usados nos flows `materialize_<modo>`: para as tabelas `gps_brt` e `gps_sppo`
- Adiciona novas constantes em `rj_smtr/constants.py`: `GPS_<modo>_RAW_DATASET_ID`, para lidar com o caso de não ter uma `last_run_timestamp` setada no Redis.