### PR TITLE
fix(smtr/redis): ajusta `last_run_timestamp` ⏱

### DIFF
--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -551,14 +551,13 @@ def set_last_run_timestamp(
         _type_: _description_
     """
     redis_client = get_redis_client()
-    update_dict = {
-        table_id: {
-            "last_run_timestamp": datetime.now(
-                timezone(constants.TIMEZONE.value)
-            ).strftime("%Y-%m-%dT%H:%M:%S")
-        }
+    key = dataset_id + "." + table_id
+    value = {
+        "last_run_timestamp": datetime.now(timezone(constants.TIMEZONE.value)).strftime(
+            "%Y-%m-%dT%H:%M:%S"
+        )
     }
-    redis_client.set(dataset_id, update_dict)
+    redis_client.set(key, value)
     return True
 
 

--- a/pipelines/rj_smtr/utils.py
+++ b/pipelines/rj_smtr/utils.py
@@ -149,11 +149,12 @@ def get_last_run_timestamp(dataset_id: str, table_id: str):
         Union[str, None]: _description_
     """
     redis_client = get_redis_client()
-    runs = redis_client.get(dataset_id)
-    if runs is None:
-        redis_client.set(dataset_id, {table_id: ""})
+    key = dataset_id + "." + table_id
+    runs = redis_client.get(key)
+    # if runs is None:
+    #     redis_client.set(key, "")
     try:
-        last_run_timestamp = runs[table_id]["last_run_timestamp"]
+        last_run_timestamp = runs["last_run_timestamp"]
     except KeyError:
         return None
     except TypeError:


### PR DESCRIPTION
- Torna as `keys` do `redis` especificas para `dataset_id+table_id`