### PR TITLE
fix(smtr/gps_stpl): desativa captura gps ⏸ 

### DIFF
--- a/pipelines/rj_smtr/br_rj_riodejaneiro_stpl_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_stpl_gps/flows.py
@@ -86,4 +86,4 @@ stpl_captura.run_config = KubernetesRun(
     image=emd_constants.DOCKER_IMAGE.value,
     labels=[emd_constants.RJ_SMTR_AGENT_LABEL.value],
 )
-stpl_captura.schedule = every_minute
+# stpl_captura.schedule = every_minute

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_stpl_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_stpl_gps/flows.py
@@ -16,7 +16,7 @@ from pipelines.utils.decorators import Flow
 
 from pipelines.rj_smtr.constants import constants
 
-from pipelines.rj_smtr.schedules import every_minute
+# from pipelines.rj_smtr.schedules import every_minute
 from pipelines.rj_smtr.tasks import (
     create_current_date_hour_partition,
     create_local_partition_path,


### PR DESCRIPTION
Ainda mantemos a captura no Dagster, na próxima semana voltamos para avaliar e consertar a pipeline.