### PR TITLE
fix(smtr/mat): corrije data da última materialização ⌛️

### DIFF
--- a/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
@@ -88,7 +88,7 @@ with Flow(
         set_last_run_timestamp(
             dataset_id=dataset_id,
             table_id=table_id,
-            timestamp=date_range["date_end"],
+            timestamp=date_range["date_range_end"],
             wait=RUN,
         )
     with case(rebuild, False):
@@ -102,7 +102,7 @@ with Flow(
         set_last_run_timestamp(
             dataset_id=dataset_id,
             table_id=table_id,
-            timestamp=date_range["date_end"],
+            timestamp=date_range["date_range_end"],
             wait=RUN,
         )
 

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
@@ -85,7 +85,12 @@ with Flow(
             _vars=[date_range, dataset_sha],
             flags="--full-refresh",
         )
-        set_last_run_timestamp(dataset_id=dataset_id, table_id=table_id, wait=RUN)
+        set_last_run_timestamp(
+            dataset_id=dataset_id,
+            table_id=table_id,
+            timestamp=date_range["date_end"],
+            wait=RUN,
+        )
     with case(rebuild, False):
         RUN = run_dbt_model(
             dbt_client=dbt_client,
@@ -94,7 +99,12 @@ with Flow(
             exclude="+data_versao_efetiva",
             _vars=[date_range, dataset_sha],
         )
-        set_last_run_timestamp(dataset_id=dataset_id, table_id=table_id, wait=RUN)
+        set_last_run_timestamp(
+            dataset_id=dataset_id,
+            table_id=table_id,
+            timestamp=date_range["date_end"],
+            wait=RUN,
+        )
 
 
 with Flow(

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -84,7 +84,12 @@ with Flow(
             _vars=[date_range, dataset_sha],
             flags="--full-refresh",
         )
-        set_last_run_timestamp(dataset_id=dataset_id, table_id=table_id, wait=RUN)
+        set_last_run_timestamp(
+            dataset_id=dataset_id,
+            table_id=table_id,
+            timestamp=date_range["date_end"],
+            wait=RUN,
+        )
     with case(rebuild, False):
         RUN = run_dbt_model(
             dbt_client=dbt_client,
@@ -93,7 +98,12 @@ with Flow(
             _vars=[date_range, dataset_sha],
             upstream=True,
         )
-        set_last_run_timestamp(dataset_id=dataset_id, table_id=table_id, wait=RUN)
+        set_last_run_timestamp(
+            dataset_id=dataset_id,
+            table_id=table_id,
+            timestamp=date_range["date_end"],
+            wait=RUN,
+        )
 
 
 with Flow(

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -87,7 +87,7 @@ with Flow(
         set_last_run_timestamp(
             dataset_id=dataset_id,
             table_id=table_id,
-            timestamp=date_range["date_end"],
+            timestamp=date_range["date_range_end"],
             wait=RUN,
         )
     with case(rebuild, False):
@@ -101,7 +101,7 @@ with Flow(
         set_last_run_timestamp(
             dataset_id=dataset_id,
             table_id=table_id,
-            timestamp=date_range["date_end"],
+            timestamp=date_range["date_range_end"],
             wait=RUN,
         )
 

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -533,7 +533,7 @@ def get_materialization_date_range(
 
 @task
 def set_last_run_timestamp(
-    dataset_id: str, table_id: str, wait=None
+    dataset_id: str, table_id: str, timestamp: str, wait=None
 ):  # pylint: disable=unused-argument
     """
     Set the `last_run_timestamp` key for the dataset_id/table_id pair
@@ -543,6 +543,7 @@ def set_last_run_timestamp(
     Args:
         dataset_id (str): dataset_id on BigQuery
         table_id (str): model filename on the queries repo.
+        timestamp: Last run timestamp end.
         wait (Any, optional): Used for defining dependencies inside the flow,
         in general, pass the output of the task which should be run imediately
         before this. Defaults to None.
@@ -553,9 +554,7 @@ def set_last_run_timestamp(
     redis_client = get_redis_client()
     key = dataset_id + "." + table_id
     value = {
-        "last_run_timestamp": datetime.now(timezone(constants.TIMEZONE.value)).strftime(
-            "%Y-%m-%dT%H:%M:%S"
-        )
+        "last_run_timestamp": timestamp,
     }
     redis_client.set(key, value)
     return True

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -551,14 +551,13 @@ def set_last_run_timestamp(
         _type_: _description_
     """
     redis_client = get_redis_client()
-    update_dict = {
-        table_id: {
-            "last_run_timestamp": datetime.now(
-                timezone(constants.TIMEZONE.value)
-            ).strftime("%Y-%m-%dT%H:%M:%S")
-        }
+    key = dataset_id + "." + table_id
+    value = {
+        "last_run_timestamp": datetime.now(timezone(constants.TIMEZONE.value)).strftime(
+            "%Y-%m-%dT%H:%M:%S"
+        )
     }
-    redis_client.set(dataset_id, update_dict)
+    redis_client.set(key, value)
     return True
 
 

--- a/pipelines/rj_smtr/utils.py
+++ b/pipelines/rj_smtr/utils.py
@@ -149,11 +149,12 @@ def get_last_run_timestamp(dataset_id: str, table_id: str):
         Union[str, None]: _description_
     """
     redis_client = get_redis_client()
-    runs = redis_client.get(dataset_id)
-    if runs is None:
-        redis_client.set(dataset_id, {table_id: ""})
+    key = dataset_id + "." + table_id
+    runs = redis_client.get(key)
+    # if runs is None:
+    #     redis_client.set(key, "")
     try:
-        last_run_timestamp = runs[table_id]["last_run_timestamp"]
+        last_run_timestamp = runs["last_run_timestamp"]
     except KeyError:
         return None
     except TypeError:


### PR DESCRIPTION
Descrição: Muda data da ultima materialização de `datetime.now()` para `date_range["end"]` (passada em `dbt run`). Da forma como estava antes a próxima materialização iria desconsiderar os minutos passados entre o `run_dbt_model` e o termino da `run` (1~2 minutos).