### PR TITLE
[SMTR][feat] Adiciona rename_flow_run aos flows da SMTR

### DIFF
--- a/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
@@ -12,6 +12,7 @@ from prefect.storage import GCS
 from pipelines.constants import constants as emd_constants
 from pipelines.utils.decorators import Flow
 from pipelines.utils.execute_dbt_model.tasks import get_k8s_dbt_client
+from pipelines.utils.tasks import get_now_time, rename_current_flow_run_now_time
 
 # SMTR Imports #
 
@@ -47,6 +48,11 @@ with Flow(
     code_owners=["@hellcassius#1223", "@fernandascovino#9750"],
 ) as materialize_brt:
 
+    # Rename flow run
+    rename_flow_run = rename_current_flow_run_now_time(
+        prefix="GPS BRT - Materialização: ", now_time=get_now_time()
+    )
+
     # Get default parameters #
     raw_dataset_id = Parameter(
         "raw_dataset_id", default=constants.GPS_BRT_RAW_DATASET_ID.value
@@ -59,7 +65,7 @@ with Flow(
     rebuild = Parameter("rebuild", False)
 
     # Set dbt client #
-    dbt_client = get_k8s_dbt_client(mode="prod")
+    dbt_client = get_k8s_dbt_client(mode="prod", wait=rename_flow_run)
     # Use the command below to get the dbt client in dev mode:
     # dbt_client = get_local_dbt_client(host="localhost", port=3001)
 
@@ -112,6 +118,11 @@ with Flow(
     code_owners=["@hellcassius#1223", "@fernandascovino#9750"],
 ) as captura_brt:
 
+    # Rename flow run
+    rename_flow_run = rename_current_flow_run_now_time(
+        prefix="GPS BRT - Captura: ", now_time=get_now_time()
+    )
+
     # Get default parameters #
     dataset_id = Parameter("dataset_id", default=constants.GPS_BRT_DATASET_ID.value)
     table_id = Parameter("table_id", default=constants.GPS_BRT_RAW_TABLE_ID.value)
@@ -152,6 +163,7 @@ with Flow(
         raw_filepath=raw_filepath,
         partitions=file_dict["partitions"],
     )
+    captura_brt.set_dependencies(task=file_dict, upstream_tasks=[rename_flow_run])
 
 materialize_brt.storage = GCS(emd_constants.GCS_FLOWS_BUCKET.value)
 materialize_brt.run_config = KubernetesRun(

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
@@ -120,7 +120,7 @@ with Flow(
 
     # Rename flow run
     rename_flow_run = rename_current_flow_run_now_time(
-        prefix="GPS BRT - Captura: ", now_time=get_now_time()
+        prefix="SMTR: GPS BRT - Captura - ", now_time=get_now_time()
     )
 
     # Get default parameters #

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -48,7 +48,7 @@ with Flow(
 ) as materialize_sppo:
     # Rename flow run
     rename_flow_run = rename_current_flow_run_now_time(
-        prefix="GPS SPPO - Materialização: ", now_time=get_now_time()
+        prefix="SMTR: GPS SPPO - Materialização - ", now_time=get_now_time()
     )
 
     # Get default parameters #

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -118,7 +118,7 @@ with Flow(
 
     # Rename flow run
     rename_flow_run = rename_current_flow_run_now_time(
-        prefix="GPS SPPO - Captura: ", now_time=get_now_time()
+        prefix="SMTR: GPS SPPO - Captura - ", now_time=get_now_time()
     )
 
     # Get default parameters #

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_sigmob/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_sigmob/flows.py
@@ -40,7 +40,7 @@ with Flow(
 
     # Rename Flow Run
     rename_flow_run = rename_current_flow_run_now_time(
-        prefix="SIGMOB MATERIALIZE: ", now_time=get_now_time()
+        prefix="SMTR: SIGMOB - Materialização - ", now_time=get_now_time()
     )
 
     # Get default parameters #

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_sigmob/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_sigmob/flows.py
@@ -101,7 +101,7 @@ with Flow(
 
     # Rename flow run
     rename_flow_run = rename_current_flow_run_now_time(
-        prefix="SIGMOB CAPTURA: ", now_time=get_now_time()
+        prefix="SMTR: SIGMOB - Captura - ", now_time=get_now_time()
     )
 
     # Run tasks #

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_sigmob/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_sigmob/flows.py
@@ -15,6 +15,7 @@ from pipelines.utils.decorators import Flow
 from pipelines.utils.execute_dbt_model.tasks import (
     get_k8s_dbt_client,
 )
+from pipelines.utils.tasks import rename_current_flow_run_now_time, get_now_time
 
 # SMTR Imports #
 
@@ -37,12 +38,17 @@ with Flow(
     code_owners=["@hellcassius#1223", "@fernandascovino#9750"],
 ) as materialize_sigmob:
 
+    # Rename Flow Run
+    rename_flow_run = rename_current_flow_run_now_time(
+        prefix="SIGMOB MATERIALIZE: ", now_time=get_now_time()
+    )
+
     # Get default parameters #
     dataset_id = Parameter("dataset_id", default=constants.SIGMOB_DATASET_ID.value)
     backfill = Parameter("backfill", default=False)
 
     # Set dbt client #
-    dbt_client = get_k8s_dbt_client(mode="prod")
+    dbt_client = get_k8s_dbt_client(mode="prod", wait=rename_flow_run)
     # Use the command below to get the dbt client in dev mode:
     # dbt_client = get_local_dbt_client(host="localhost", port=3001)
 
@@ -93,6 +99,11 @@ with Flow(
     dataset_id = Parameter("dataset_id", default=constants.SIGMOB_DATASET_ID.value)
     materialize = Parameter("materialize", default=True)
 
+    # Rename flow run
+    rename_flow_run = rename_current_flow_run_now_time(
+        prefix="SIGMOB CAPTURA: ", now_time=get_now_time()
+    )
+
     # Run tasks #
     paths_dict = request_data(endpoints=endpoints)
     bq_upload = bq_upload_from_dict(paths=paths_dict, dataset_id=dataset_id)
@@ -113,6 +124,7 @@ with Flow(
         stream_logs=True,
         raise_final_state=True,
     )
+    captura_sigmob.set_dependencies(task=paths_dict, upstream_tasks=[rename_flow_run])
 
 
 materialize_sigmob.storage = GCS(emd_constants.GCS_FLOWS_BUCKET.value)

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_stpl_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_stpl_gps/flows.py
@@ -42,7 +42,7 @@ with Flow(
 
     # Rename flow run
     rename_flow_run = rename_current_flow_run_now_time(
-        prefix="GPS BRT - Materialização: ", now_time=get_now_time()
+        prefix="SMTR: GPS STPL - Materialização - ", now_time=get_now_time()
     )
 
     # Get default parameters #

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_stpl_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_stpl_gps/flows.py
@@ -11,6 +11,7 @@ from prefect.storage import GCS
 
 from pipelines.constants import constants as emd_constants
 from pipelines.utils.decorators import Flow
+from pipelines.utils.tasks import rename_current_flow_run_now_time, get_now_time
 
 # SMTR Imports #
 
@@ -38,6 +39,12 @@ with Flow(
     "SMTR: GPS STPL - Captura",
     code_owners=["@hellcassius#1223", "@fernandascovino#9750"],
 ) as stpl_captura:
+
+    # Rename flow run
+    rename_flow_run = rename_current_flow_run_now_time(
+        prefix="GPS BRT - Materialização: ", now_time=get_now_time()
+    )
+
     # Get default parameters #
     dataset_id = Parameter("dataset_id", default=constants.GPS_STPL_DATASET_ID.value)
     table_id = Parameter("table_id", default=constants.GPS_STPL_RAW_TABLE_ID.value)
@@ -79,7 +86,7 @@ with Flow(
         raw_filepath=raw_filepath,
         partitions=file_dict["partitions"],
     )
-
+    stpl_captura.set_dependencies(task=file_dict, upstream_tasks=[rename_flow_run])
 
 stpl_captura.storage = GCS(emd_constants.GCS_FLOWS_BUCKET.value)
 stpl_captura.run_config = KubernetesRun(


### PR DESCRIPTION
**Descrição:**
Adiciona em todos os flows da SMTR uma task extra no início de cada uma para renomear a run.
Por padrão, nossos flows têm nomes como:
`SMTR: <dataset> - <captura/materialização>`
Com o _rename_ adicionado, as runs passam a ter o mesmo nome do flow, menos o prefixo "SMTR", mais um timestamp do `pendulum.now()` do momento que a run é inicializada. Para isso, nos valemos das tasks já implementadas em `pipelines.utils.tasks`: `rename_current_flow_run_now_time` e `get_now_time`

**Issue relacionado:** resolves #82 