### PR TITLE
feat(smtr/sppo): Adiciona flow de teste da nova API do SPPO

### DIFF
--- a/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
@@ -124,7 +124,7 @@ with Flow(
     )
 
     # Get default parameters #
-    dataset_id = Parameter("dataset_id", default=constants.GPS_BRT_DATASET_ID.value)
+    dataset_id = Parameter("dataset_id", default=constants.GPS_BRT_RAW_DATASET_ID.value)
     table_id = Parameter("table_id", default=constants.GPS_BRT_RAW_TABLE_ID.value)
     url = Parameter("url", default=constants.GPS_BRT_API_BASE_URL.value)
     # secret_path = Parameter("secret_path", default=constants.GPS_BRT_API_SECRET_PATH.value)

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -189,7 +189,7 @@ with Flow(
 
     # Rename flow run
     rename_flow_run = rename_current_flow_run_now_time(
-        prefix="SMTR: GPS SPPO - Captura Nova API - ", now_time=get_now_time()
+        prefix="SMTR: GPS SPPO - Captura API v2 - ", now_time=get_now_time()
     )
 
     # Run tasks #

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -181,7 +181,7 @@ with Flow(
     table_id = Parameter("table_id", default=constants.GPS_SPPO_RAW_TABLE_ID.value)
     url = Parameter("url", default=constants.GPS_SPPO_API_BASE_URL_V2.value)
     secret_path = Parameter(
-        "secret_path", default=constants.GPS_SPPO_API_SECRET_PATH_v2.value
+        "secret_path", default=constants.GPS_SPPO_API_SECRET_PATH_V2.value
     )
     version = Parameter("version", default=2)
 

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -252,6 +252,5 @@ captura_sppo.run_config = KubernetesRun(
 captura_sppo_v2.storage = GCS(emd_constants.GCS_FLOWS_BUCKET.value)
 captura_sppo_v2.run_config = KubernetesRun(
     image=emd_constants.DOCKER_IMAGE.value,
-    labels=[emd_constants.RJ_SMTR_AGENT_LABEL.value],
 )
 captura_sppo_v2.schedule = every_minute_dev

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -210,7 +210,7 @@ with Flow(
         status_dict=status_dict, version=version
     )
 
-    upload_logs = upload_logs_to_bq(
+    UPLOAD_LOGS = upload_logs_to_bq(
         dataset_id=dataset_id,
         parent_table_id=table_id,
         timestamp=status_dict["timestamp"],
@@ -221,7 +221,7 @@ with Flow(
         dataframe=treated_status["df"], file_path=filepath
     )
 
-    upload_csv = bq_upload(
+    UPLOAD_CSV = bq_upload(
         dataset_id=dataset_id,
         table_id=table_id,
         filepath=treated_filepath,
@@ -233,7 +233,7 @@ with Flow(
     )
     captura_sppo_v2.set_dependencies(task=file_dict, upstream_tasks=[rename_flow_run])
     captura_sppo_v2.set_dependencies(task=status_dict, upstream_tasks=[filepath])
-    captura_sppo_v2.set_dependencies(task=set_last_run, upstream_tasks=[upload_csv])
+    captura_sppo_v2.set_dependencies(task=set_last_run, upstream_tasks=[UPLOAD_CSV])
 
 materialize_sppo.storage = GCS(emd_constants.GCS_FLOWS_BUCKET.value)
 materialize_sppo.run_config = KubernetesRun(

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -122,7 +122,9 @@ with Flow(
     )
 
     # Get default parameters #
-    dataset_id = Parameter("dataset_id", default=constants.GPS_SPPO_DATASET_ID.value)
+    dataset_id = Parameter(
+        "dataset_id", default=constants.GPS_SPPO_RAW_DATASET_ID.value
+    )
     table_id = Parameter("table_id", default=constants.GPS_SPPO_RAW_TABLE_ID.value)
     url = Parameter("url", default=constants.GPS_SPPO_API_BASE_URL.value)
     secret_path = Parameter(

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
@@ -16,7 +16,7 @@ from pipelines.utils.utils import log
 # SMTR Imports #
 
 from pipelines.rj_smtr.constants import constants
-from pipelines.rj_smtr.utils import log_critical
+from pipelines.rj_smtr.utils import log_critical, sppo_filters
 
 # Tasks #
 
@@ -64,31 +64,55 @@ def pre_treatment_br_rj_riodejaneiro_onibus_gps(status_dict: dict, version: int 
         )
     )
     log(f"After converting the timezone, datahora is: \n{df['datahora']}")
+    if version == 2:
+        df["datahoraenvio"] = (
+            df["datahoraenvio"]
+            .astype(float)
+            .apply(
+                lambda ms: pd.to_datetime(
+                    pendulum.from_timestamp(ms / 1000.0)
+                    .replace(tzinfo=None)
+                    .set(tz="UTC")
+                    .isoformat()
+                )
+            )
+        )
+        df["datahoraservidor"] = (
+            df["datahoraservidor"]
+            .astype(float)
+            .apply(
+                lambda ms: pd.to_datetime(
+                    pendulum.from_timestamp(ms / 1000.0)
+                    .replace(tzinfo=None)
+                    .set(tz="UTC")
+                    .isoformat()
+                )
+            )
+        )
 
     # Filter data for 0 <= time diff <= 1min
     try:
-        datahora_col = "datahora"
+        datahora_cols = [
+            "datahora",
+            "datahoraenvio",
+            "datahoraservidor",
+            "timestamp_captura",
+        ]
+        # datahora_col = "datahora"
         df_treated = df
-        try:
-            df_treated[datahora_col] = df_treated[datahora_col].apply(
-                lambda x: x.tz_convert(timezone)
-            )
-        except TypeError:
-            df_treated[datahora_col] = df_treated[datahora_col].apply(
-                lambda x: x.tz_localize(timezone)
-            )
-        try:
-            df_treated["timestamp_captura"] = df_treated["timestamp_captura"].apply(
-                lambda x: x.tz_convert(timezone)
-            )
-        except TypeError:
-            df_treated["timestamp_captura"] = df_treated["timestamp_captura"].apply(
-                lambda x: x.tz_localize(timezone)
-            )
-        mask = (df_treated["timestamp_captura"] - df_treated[datahora_col]).apply(
-            lambda x: timedelta(seconds=0) <= x <= timedelta(minutes=1)
-        )
-        df_treated = df_treated[mask]
+        for col in datahora_cols:
+            if col in df_treated.columns.to_list():
+                try:
+                    df_treated[col] = df_treated[col].apply(
+                        lambda x: x.tz_convert(timezone)
+                    )
+                except TypeError:
+                    df_treated[col] = df_treated[col].apply(
+                        lambda x: x.tz_localize(timezone)
+                    )
+
+        # filters
+        df_treated = sppo_filters(df=df_treated)
         log(f"Shape antes da filtragem: {df.shape}")
         log(f"Shape após a filtragem: {df_treated.shape}")
         if df_treated.shape[0] == 0:

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
@@ -111,7 +111,7 @@ def pre_treatment_br_rj_riodejaneiro_onibus_gps(status_dict: dict, version: int 
                     )
 
         # filters
-        df_treated = sppo_filters(df=df_treated)
+        df_treated = sppo_filters(df=df_treated, version=version)
         log(f"Shape antes da filtragem: {df.shape}")
         log(f"Shape após a filtragem: {df_treated.shape}")
         if df_treated.shape[0] == 0:

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
@@ -3,7 +3,6 @@
 Tasks for br_rj_riodejaneiro_onibus_gps
 """
 
-from datetime import timedelta
 import traceback
 import pandas as pd
 import pendulum

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
@@ -22,13 +22,14 @@ from pipelines.rj_smtr.utils import log_critical
 
 
 @task
-def pre_treatment_br_rj_riodejaneiro_onibus_gps(status_dict: dict):
+def pre_treatment_br_rj_riodejaneiro_onibus_gps(status_dict: dict, version: int = 1):
     """Basic data treatment for bus gps data. Converts unix time to datetime,
     and apply filtering to stale data that may populate the API response.
 
     Args:
         status_dict (dict): dict containing the status of the request made to the
         API. Must contain keys: data, timestamp and error
+        version (int, optional): Source API version. Temporary argument for testing
 
     Returns:
         df: pandas.core.DataFrame containing the treated data.

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
@@ -108,9 +108,9 @@ def pre_treatment_br_rj_riodejaneiro_onibus_gps(status_dict: dict, version: int 
             error = ValueError("After filtering, the dataframe is empty!")
             log_critical(f"@here\nFailed to filter SPPO data: \n{error}")
         if version == 2:
-            df = df_treated.drop(
+            df = df_treated.drop(  # pylint: disable=C0103
                 columns=["datahoraenvio", "datahoraservidor"]
-            )  # pylint: disable=C0103
+            )
         else:
             df = df_treated  # pylint: disable=C0103
     except Exception:  # pylint: disable = W0703

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
@@ -118,7 +118,9 @@ def pre_treatment_br_rj_riodejaneiro_onibus_gps(status_dict: dict, version: int 
         if df_treated.shape[0] == 0:
             error = ValueError("After filtering, the dataframe is empty!")
             log_critical(f"@here\nFailed to filter SPPO data: \n{error}")
-        df = df_treated  # pylint: disable=C0103
+        df = df_treated.drop(
+            columns=["datahoraenvio", "datahoraservidor"]
+        )  # pylint: disable=C0103
     except Exception:  # pylint: disable = W0703
         err = traceback.format_exc()
         log_critical(f"@here\nFailed to filter SPPO data: \n{err}")

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
@@ -15,7 +15,8 @@ from pipelines.utils.utils import log
 # SMTR Imports #
 
 from pipelines.rj_smtr.constants import constants
-from pipelines.rj_smtr.utils import log_critical, sppo_filters
+from pipelines.rj_smtr.utils import log_critical
+from pipelines.rj_smtr.br_rj_riodejaneiro_onibus_gps.utils import sppo_filters
 
 # Tasks #
 

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/utils.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/utils.py
@@ -54,5 +54,4 @@ def sppo_filters(frame: pd.DataFrame, version: int = 1):
             <= x
             <= timedelta(minutes=constants.GPS_SPPO_CAPTURE_DELAY.value)
         )
-        frame = frame[sent_received_mask]
-        return frame
+        return frame[sent_received_mask]

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/utils.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/utils.py
@@ -55,3 +55,4 @@ def sppo_filters(frame: pd.DataFrame, version: int = 1):
             <= timedelta(minutes=constants.GPS_SPPO_CAPTURE_DELAY.value)
         )
         return frame[sent_received_mask]
+    return frame

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/utils.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/utils.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""
+General purpose functions for the br_rj_riodejaneiro_onibus_gps project
+"""
+###############################################################################
+#
+# Esse é um arquivo onde podem ser declaratas funções que serão usadas
+# pelo projeto br_rj_riodejaneiro_onibus_gps.
+#
+# Por ser um arquivo opcional, pode ser removido sem prejuízo ao funcionamento
+# do projeto, caos não esteja em uso.
+#
+# Para declarar funções, basta fazer em código Python comum, como abaixo:
+#
+# ```
+# def foo():
+#     """
+#     Function foo
+#     """
+#     print("foo")
+# ```
+#
+# Para usá-las, basta fazer conforme o exemplo abaixo:
+#
+# ```py
+# from pipelines.rj_smtr.br_rj_riodejaneiro_onibus_gps.utils import foo
+# foo()
+# ```
+#
+###############################################################################
+from datetime import timedelta
+import pandas as pd
+from pipelines.rj_smtr.constants import constants
+
+
+def sppo_filters(frame: pd.DataFrame, version: int = 1):
+    """Apply filters to dataframe
+
+    Args:
+        frame (pd.DataFrame): Containing data captured from sppo
+        api
+
+    Returns:
+        frame: Filtered input
+    """
+    if version == 1:
+        same_minute_mask = (frame["timestamp_captura"] - frame["datahora"]).apply(
+            lambda x: timedelta(seconds=0) <= x <= timedelta(minutes=1)
+        )
+        return frame[same_minute_mask]
+    if version == 2:
+        sent_received_mask = (frame["datahoraenvio"] - frame["datahora"]).apply(
+            lambda x: timedelta(seconds=0)
+            <= x
+            <= timedelta(minutes=constants.GPS_SPPO_CAPTURE_DELAY.value)
+        )
+        frame = frame[sent_received_mask]
+        return frame

--- a/pipelines/rj_smtr/constants.py
+++ b/pipelines/rj_smtr/constants.py
@@ -34,6 +34,9 @@ class constants(Enum):  # pylint: disable=c0103
     GPS_SPPO_API_BASE_URL = (
         "http://ccomobility.com.br/WebServices/Binder/WSConecta/EnvioInformacoesIplan?"
     )
+    GPS_SPPO_API_BASE_URL_V2 = (
+        "http://ccomobility.com.br/WebServices/Binder/wsconecta/EnvioIplan?"
+    )
     GPS_SPPO_API_SECRET_PATH = "sppo_api"
 
     GPS_SPPO_RAW_DATASET_ID = "br_rj_riodejaneiro_onibus_gps"

--- a/pipelines/rj_smtr/constants.py
+++ b/pipelines/rj_smtr/constants.py
@@ -38,6 +38,7 @@ class constants(Enum):  # pylint: disable=c0103
         "http://ccomobility.com.br/WebServices/Binder/wsconecta/EnvioIplan?"
     )
     GPS_SPPO_API_SECRET_PATH = "sppo_api"
+    GPS_SPPO_API_SECRET_PATH_v2 = "sppo_api_v2"
 
     GPS_SPPO_RAW_DATASET_ID = "br_rj_riodejaneiro_onibus_gps"
     GPS_SPPO_RAW_TABLE_ID = "registros"

--- a/pipelines/rj_smtr/constants.py
+++ b/pipelines/rj_smtr/constants.py
@@ -43,6 +43,7 @@ class constants(Enum):  # pylint: disable=c0103
     GPS_SPPO_RAW_TABLE_ID = "registros"
     GPS_SPPO_DATASET_ID = "br_rj_riodejaneiro_veiculos"
     GPS_SPPO_TREATED_TABLE_ID = "gps_sppo"
+    GPS_SPPO_CAPTURE_DELAY = 10
 
     # GPS BRT #
     GPS_BRT_API_BASE_URL = (

--- a/pipelines/rj_smtr/constants.py
+++ b/pipelines/rj_smtr/constants.py
@@ -38,7 +38,7 @@ class constants(Enum):  # pylint: disable=c0103
         "http://ccomobility.com.br/WebServices/Binder/wsconecta/EnvioIplan?"
     )
     GPS_SPPO_API_SECRET_PATH = "sppo_api"
-    GPS_SPPO_API_SECRET_PATH_v2 = "sppo_api_v2"
+    GPS_SPPO_API_SECRET_PATH_V2 = "sppo_api_v2"
 
     GPS_SPPO_RAW_DATASET_ID = "br_rj_riodejaneiro_onibus_gps"
     GPS_SPPO_RAW_TABLE_ID = "registros"

--- a/pipelines/rj_smtr/schedules.py
+++ b/pipelines/rj_smtr/schedules.py
@@ -23,6 +23,19 @@ every_minute = Schedule(
         ),
     ]
 )
+every_minute_dev = Schedule(
+    clocks=[
+        IntervalClock(
+            interval=timedelta(minutes=1),
+            start_date=datetime(
+                2021, 1, 1, 0, 0, 0, tzinfo=timezone(constants.TIMEZONE.value)
+            ),
+            labels=[
+                emd_constants.RJ_SMTR_DEV_AGENT_LABEL.value,
+            ],
+        ),
+    ]
+)
 
 every_hour = Schedule(
     clocks=[

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -326,7 +326,6 @@ def get_raw(url, headers=None, source: str = None):
         url = f"{url}{key}={access[key]}"
         url += f"&dataInicial={(timestamp - timedelta(minutes=2)).strftime('%Y-%m-%d%%%d%H:%M:%S')}"
         url += f"&dataFinal={timestamp.strftime('%Y-%m-%d%%%d%H:%M:%S')}"
-        return url
     try:
         data = requests.get(
             url, headers=headers, timeout=constants.MAX_TIMEOUT_SECONDS.value

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -297,15 +297,15 @@ def save_treated_local(dataframe, file_path, mode="staging"):
 ###############
 
 
-@task
+# @task
 def get_raw(url, headers=None, source: str = None):
     """Request data from a url API
 
     Args:
         url (str): URL to send request to
         headers (dict, optional): Aditional fields to send along the request. Defaults to None.
-        kind (str, optional): Kind of API being captured.
-        Possible values are 'stpl', 'brt' and 'sppo'
+        source (str, optional): Source API being captured.
+        Possible values are 'stpl_api', 'brt_api', 'sppo_api' and 'sppo_api_v2
     Returns:
         dict: "data" contains the response object from the request, "timestamp" contains
         the run time timestamp, "error" catches errors that may occur during task execution.
@@ -319,6 +319,12 @@ def get_raw(url, headers=None, source: str = None):
     data = None
     error = None
     timestamp = pendulum.now(constants.TIMEZONE.value)
+    if source == "sppo_api_v2":
+        access = get_vault_secret(source)["data"]
+        key = list(access)[0]
+        url = f"{url}{key}={access[key]}"
+        url += f"&data={timestamp.strftime('%Y-%m-%d%%%d%H:%M:%S')}"
+        return url
     try:
         data = requests.get(
             url, headers=headers, timeout=constants.MAX_TIMEOUT_SECONDS.value

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -297,7 +297,7 @@ def save_treated_local(dataframe, file_path, mode="staging"):
 ###############
 
 
-# @task
+@task
 def get_raw(url, headers=None, source: str = None):
     """Request data from a url API
 
@@ -320,6 +320,7 @@ def get_raw(url, headers=None, source: str = None):
     error = None
     timestamp = pendulum.now(constants.TIMEZONE.value)
     if source == "sppo_api_v2":
+        log("Will request data from v2 API")
         access = get_vault_secret(source)["data"]
         key = list(access)[0]
         url = f"{url}{key}={access[key]}"

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -320,12 +320,11 @@ def get_raw(url, headers=None, source: str = None):
     error = None
     timestamp = pendulum.now(constants.TIMEZONE.value)
     if source == "sppo_api_v2":
-        log("Will request data from v2 API")
         access = get_vault_secret(source)["data"]
         key = list(access)[0]
         url = f"{url}{key}={access[key]}"
-        url += f"&dataInicial={(timestamp - timedelta(minutes=2)).strftime('%Y-%m-%d%%%d%H:%M:%S')}"
-        url += f"&dataFinal={timestamp.strftime('%Y-%m-%d%%%d%H:%M:%S')}"
+        url += f"&dataInicial={(timestamp - timedelta(minutes=1)).strftime('%Y-%m-%d+%H:%M:%S')}"
+        url += f"&dataFinal={timestamp.strftime('%Y-%m-%d+%H:%M:%S')}"
     try:
         data = requests.get(
             url, headers=headers, timeout=constants.MAX_TIMEOUT_SECONDS.value

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -485,8 +485,8 @@ def upload_logs_to_bq(dataset_id, parent_table_id, timestamp, error):
     checkpoint=False,
     max_retries=constants.MAX_RETRIES.value,
     retry_delay=timedelta(seconds=constants.RETRY_DELAY.value),
-)  # pylint: disable=R0913
-def get_materialization_date_range(
+)
+def get_materialization_date_range(  # pylint: disable=R0913
     dataset_id: str,
     table_id: str,
     raw_dataset_id: str,

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -323,7 +323,8 @@ def get_raw(url, headers=None, source: str = None):
         access = get_vault_secret(source)["data"]
         key = list(access)[0]
         url = f"{url}{key}={access[key]}"
-        url += f"&data={timestamp.strftime('%Y-%m-%d%%%d%H:%M:%S')}"
+        url += f"&dataInicial={(timestamp - timedelta(minutes=2)).strftime('%Y-%m-%d%%%d%H:%M:%S')}"
+        url += f"&dataFinal={timestamp.strftime('%Y-%m-%d%%%d%H:%M:%S')}"
         return url
     try:
         data = requests.get(

--- a/pipelines/rj_smtr/utils.py
+++ b/pipelines/rj_smtr/utils.py
@@ -219,27 +219,3 @@ def safe_cast(val, to_type, default=None):
         return to_type(val)
     except ValueError:
         return default
-
-
-def sppo_filters(frame: pd.DataFrame, version: int = 1):
-    """Apply filters to dataframe
-
-    Args:
-        frame (pd.DataFrame): Containing data captured from sppo
-        api
-
-    Returns:
-        frame: Filtered input
-    """
-    if version == 1:
-        same_minute_mask = (frame["timestamp_captura"] - frame["datahora"]).apply(
-            lambda x: timedelta(seconds=0) <= x <= timedelta(minutes=1)
-        )
-        return frame[same_minute_mask]
-    sent_received_mask = (frame["datahoraenvio"] - frame["datahora"]).apply(
-        lambda x: timedelta(seconds=0)
-        <= x
-        <= timedelta(minutes=constants.GPS_SPPO_CAPTURE_DELAY.value)
-    )
-    frame = frame[sent_received_mask]
-    return frame

--- a/pipelines/rj_smtr/utils.py
+++ b/pipelines/rj_smtr/utils.py
@@ -185,17 +185,26 @@ def safe_cast(val, to_type, default=None):
         return default
 
 
-def sppo_filters(df: pd.DataFrame):
-    if "datahoraenvio" not in df.columns.to_list():
+def sppo_filters(frame: pd.DataFrame):
+    """Apply filters to dataframe
+
+    Args:
+        df (pd.DataFrame): Containing data captured from sppo
+        api
+
+    Returns:
+        frame: Filtered input
+    """
+    if "datahoraenvio" not in frame.columns.to_list():
         log("No column named datahoraenvio on data")
-        return df
-    sent_received_mask = (df["datahoraenvio"] - df["datahora"]).apply(
+        return frame
+    sent_received_mask = (frame["datahoraenvio"] - frame["datahora"]).apply(
         lambda x: timedelta(seconds=0)
         <= x
         <= timedelta(minutes=constants.GPS_SPPO_CAPTURE_DELAY.value)
     )
-    same_minute_mask = (df["timestamp_captura"] - df["datahoraenvio"]).apply(
+    same_minute_mask = (frame["timestamp_captura"] - frame["datahoraenvio"]).apply(
         lambda x: timedelta(seconds=0) <= x <= timedelta(minutes=1)
     )
-    df = df[sent_received_mask & same_minute_mask]
-    return df
+    frame = frame[sent_received_mask & same_minute_mask]
+    return frame

--- a/pipelines/rj_smtr/utils.py
+++ b/pipelines/rj_smtr/utils.py
@@ -185,7 +185,7 @@ def safe_cast(val, to_type, default=None):
         return default
 
 
-def sppo_filters(frame: pd.DataFrame):
+def sppo_filters(frame: pd.DataFrame, version: int = 1):
     """Apply filters to dataframe
 
     Args:
@@ -195,16 +195,19 @@ def sppo_filters(frame: pd.DataFrame):
     Returns:
         frame: Filtered input
     """
-    if "datahoraenvio" not in frame.columns.to_list():
-        log("No column named datahoraenvio on data")
-        return frame
-    sent_received_mask = (frame["datahoraenvio"] - frame["datahora"]).apply(
-        lambda x: timedelta(seconds=0)
-        <= x
-        <= timedelta(minutes=constants.GPS_SPPO_CAPTURE_DELAY.value)
-    )
-    same_minute_mask = (frame["timestamp_captura"] - frame["datahoraenvio"]).apply(
-        lambda x: timedelta(seconds=0) <= x <= timedelta(minutes=1)
-    )
-    frame = frame[sent_received_mask & same_minute_mask]
+    if version == 1:
+        same_minute_mask = (frame["timestamp_captura"] - frame["datahora"]).apply(
+            lambda x: timedelta(seconds=0) <= x <= timedelta(minutes=1)
+        )
+        return frame[same_minute_mask]
+    else:
+        sent_received_mask = (frame["datahoraenvio"] - frame["datahora"]).apply(
+            lambda x: timedelta(seconds=0)
+            <= x
+            <= timedelta(minutes=constants.GPS_SPPO_CAPTURE_DELAY.value)
+        )
+        same_minute_mask = (frame["timestamp_captura"] - frame["datahoraenvio"]).apply(
+            lambda x: timedelta(seconds=0) <= x <= timedelta(minutes=1)
+        )
+        frame = frame[sent_received_mask & same_minute_mask]
     return frame

--- a/pipelines/rj_smtr/utils.py
+++ b/pipelines/rj_smtr/utils.py
@@ -186,6 +186,9 @@ def safe_cast(val, to_type, default=None):
 
 
 def sppo_filters(df: pd.DataFrame):
+    if "datahoraenvio" not in df.columns.to_list():
+        log("No column named datahoraenvio on data")
+        return df
     sent_received_mask = (df["datahoraenvio"] - df["datahora"]).apply(
         lambda x: timedelta(seconds=0)
         <= x

--- a/pipelines/rj_smtr/utils.py
+++ b/pipelines/rj_smtr/utils.py
@@ -189,7 +189,7 @@ def sppo_filters(frame: pd.DataFrame, version: int = 1):
     """Apply filters to dataframe
 
     Args:
-        df (pd.DataFrame): Containing data captured from sppo
+        frame (pd.DataFrame): Containing data captured from sppo
         api
 
     Returns:
@@ -206,8 +206,5 @@ def sppo_filters(frame: pd.DataFrame, version: int = 1):
             <= x
             <= timedelta(minutes=constants.GPS_SPPO_CAPTURE_DELAY.value)
         )
-        same_minute_mask = (frame["timestamp_captura"] - frame["datahoraenvio"]).apply(
-            lambda x: timedelta(seconds=0) <= x <= timedelta(minutes=1)
-        )
-        frame = frame[sent_received_mask & same_minute_mask]
+        frame = frame[sent_received_mask]
     return frame

--- a/pipelines/rj_smtr/utils.py
+++ b/pipelines/rj_smtr/utils.py
@@ -3,6 +3,7 @@
 General purpose functions for rj_smtr
 """
 
+from datetime import timedelta
 from pathlib import Path
 
 import basedosdados as bd
@@ -182,3 +183,16 @@ def safe_cast(val, to_type, default=None):
         return to_type(val)
     except ValueError:
         return default
+
+
+def sppo_filters(df: pd.DataFrame):
+    sent_received_mask = (df["datahoraenvio"] - df["datahora"]).apply(
+        lambda x: timedelta(seconds=0)
+        <= x
+        <= timedelta(minutes=constants.GPS_SPPO_CAPTURE_DELAY.value)
+    )
+    same_minute_mask = (df["timestamp_captura"] - df["datahoraenvio"]).apply(
+        lambda x: timedelta(seconds=0) <= x <= timedelta(minutes=1)
+    )
+    df = df[sent_received_mask & same_minute_mask]
+    return df


### PR DESCRIPTION
Descrição breve:
Adiciona o flow `captura_sppo_v2`,  para testar os conteúdos da nova API do SPPO.
Adiciona um nova parâmetro `version`, para controlar o pré tratamento realizado, além de adicionar uma condicional em `pipelines.rj_smtr.tasks`::`get_raw` para aceitar `sppo_api_v2` como valor de `source`.
Além disso, corrige um bug nos flows de captura de ambos SPPO e BRT, onde o dataset_id passado para o upload era o `br_rj_riodejaneiro_veiculos` devido à troca de nome das constantes.

TODO:
- [x] Adicionar filtro final nas colunas do dataframe no pré tratamento

- [x] Adicionar Schedule