### PR TITLE
[smtr][sppo] Adiciona catch de erro durante a requisição de dados na api v2

### DIFF
--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -228,11 +228,7 @@ with Flow(
         raw_filepath=raw_filepath,
         partitions=file_dict["partitions"],
     )
-    set_last_run = set_request_last_run_timestamp(  # pylint: disable=C0103
-        source=secret_path, mode=mode, timestamp=status_dict["timestamp"]
-    )
     captura_sppo_v2.set_dependencies(task=status_dict, upstream_tasks=[filepath])
-    captura_sppo_v2.set_dependencies(task=set_last_run, upstream_tasks=[UPLOAD_CSV])
 
 materialize_sppo.storage = GCS(emd_constants.GCS_FLOWS_BUCKET.value)
 materialize_sppo.run_config = KubernetesRun(

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -33,7 +33,6 @@ from pipelines.rj_smtr.tasks import (
     save_raw_local,
     save_treated_local,
     set_last_run_timestamp,
-    set_request_last_run_timestamp,
     upload_logs_to_bq,
     bq_upload,
 )
@@ -184,7 +183,6 @@ with Flow(
     secret_path = Parameter(
         "secret_path", default=constants.GPS_SPPO_API_SECRET_PATH_V2.value
     )
-    mode = Parameter("mode", default="dev")
     version = Parameter("version", default=2)
 
     # Run tasks #
@@ -197,7 +195,7 @@ with Flow(
         partitions=file_dict["partitions"],
     )
 
-    status_dict = get_raw(url=url, source=secret_path, mode=mode)
+    status_dict = get_raw(url=url, source=secret_path)
 
     # Rename flow run
     rename_flow_run = rename_current_flow_run_now_time(

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -187,11 +187,6 @@ with Flow(
     mode = Parameter("mode", default="dev")
     version = Parameter("version", default=2)
 
-    # Rename flow run
-    rename_flow_run = rename_current_flow_run_now_time(
-        prefix="SMTR: GPS SPPO - Captura API v2 - ", now_time=get_now_time()
-    )
-
     # Run tasks #
     file_dict = create_current_date_hour_partition()
 
@@ -203,6 +198,11 @@ with Flow(
     )
 
     status_dict = get_raw(url=url, source=secret_path, mode=mode)
+
+    # Rename flow run
+    rename_flow_run = rename_current_flow_run_now_time(
+        prefix="GPS SPPO: ", now_time=status_dict["timestamp"]
+    )
 
     raw_filepath = save_raw_local(data=status_dict["data"], file_path=filepath)
 
@@ -231,7 +231,6 @@ with Flow(
     set_last_run = set_request_last_run_timestamp(  # pylint: disable=C0103
         source=secret_path, mode=mode, timestamp=status_dict["timestamp"]
     )
-    captura_sppo_v2.set_dependencies(task=file_dict, upstream_tasks=[rename_flow_run])
     captura_sppo_v2.set_dependencies(task=status_dict, upstream_tasks=[filepath])
     captura_sppo_v2.set_dependencies(task=set_last_run, upstream_tasks=[UPLOAD_CSV])
 

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -332,30 +332,20 @@ def get_raw(url, headers=None, source: str = None, mode: str = "prod"):
         data = requests.get(
             url, headers=headers, timeout=constants.MAX_TIMEOUT_SECONDS.value
         )
-    except requests.exceptions.ReadTimeout as err:
-        error = err
     except Exception as err:
-        error = f"Unknown exception while trying to fetch data from {url}: {err}"
+        log(f"Request failed with error:\n{err}")
+        return {"data": data, "timestamp": timestamp.isoformat(), "error": err}
 
-    if isinstance(data.json(), dict) and "DescricaoErro" in data.json().keys():
-        log(f"Data is {data.json()}\n With type: {type(data.json())}")
-        if error is None:
-            error = data.json()["DescricaoErro"]
-    if data is None:
-        if error is None:
-            error = "Data from API is none!"
-
-    if error:
-        return {"data": data, "timestamp": timestamp.isoformat(), "error": error}
     if data.ok:
+        if isinstance(data.json(), dict) and "DescricaoErro" in data.json().keys():
+            log(f"Data is {data.json()}\n With type: {type(data.json())}")
+            error = data.json()["DescricaoErro"]
         return {
             "data": data,
             "error": error,
             "timestamp": timestamp.isoformat(),
         }
-    log(
-        f"Data is {data.json()}\n With type: {type(data.json())}\n And keys {data.json().keys()}"
-    )
+
     error = f"Requests failed with error {data.status_code}"
     return {"error": error, "timestamp": timestamp.isoformat(), "data": data}
 

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -337,7 +337,7 @@ def get_raw(url, headers=None, source: str = None, mode: str = "prod"):
     except Exception as err:
         error = f"Unknown exception while trying to fetch data from {url}: {err}"
 
-    if type(data.json()) is dict and "DescricaoErro" in data.json().keys():
+    if isinstance(data.json(), dict) and "DescricaoErro" in data.json().keys():
         log(f"Data is {data.json()}\n With type: {type(data.json())}")
         if error is None:
             error = data.json()["DescricaoErro"]

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -324,7 +324,6 @@ def get_raw(url, headers=None, source: str = None, mode: str = "prod"):
         access = get_vault_secret(source)["data"]
         key = list(access)[0]
         url = f"{url}{key}={access[key]}"
-        get_request_date_range
         date_range = {
             "start": (timestamp - timedelta(minutes=1)).strftime("%Y-%m-%d+%H:%M:%S"),
             "end": timestamp.strftime("%Y-%m-%d+%H:%M:%S"),

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -324,10 +324,16 @@ def get_raw(url, headers=None, source: str = None, mode: str = "prod"):
         access = get_vault_secret(source)["data"]
         key = list(access)[0]
         url = f"{url}{key}={access[key]}"
-        date_range = get_request_date_range(source=source, mode=mode)
-        log(f"Will request data between {date_range['start']} and {date_range['end']}")
-        url += f"&dataInicial={date_range['start'].replace('+', ' ')}"
-        url += f"&dataFinal={date_range['end'].replace('+', ' ')}"
+        get_request_date_range
+        date_range = {
+            "start": (timestamp - timedelta(minutes=1)).strftime("%Y-%m-%d+%H:%M:%S"),
+            "end": timestamp.strftime("%Y-%m-%d+%H:%M:%S"),
+        }
+        print(
+            f"Will request data between {date_range['start']} and {date_range['end']}"
+        )
+        url += f"&dataInicial={date_range['start']}"
+        url += f"&dataFinal={date_range['end']}"
     try:
         data = requests.get(
             url, headers=headers, timeout=constants.MAX_TIMEOUT_SECONDS.value

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -25,7 +25,6 @@ from pipelines.rj_smtr.utils import (
     bq_project,
     get_table_min_max_value,
     get_last_run_timestamp,
-    get_request_date_range,
     parse_dbt_logs,
 )
 from pipelines.utils.execute_dbt_model.utils import get_dbt_client
@@ -299,7 +298,11 @@ def save_treated_local(dataframe, file_path, mode="staging"):
 
 
 @task
-def get_raw(url, headers=None, source: str = None, mode: str = "prod"):
+def get_raw(
+    url,
+    headers=None,
+    source: str = None,
+):
     """Request data from a url API
 
     Args:
@@ -571,31 +574,6 @@ def set_last_run_timestamp(
     value = {
         "last_run_timestamp": timestamp,
     }
-    redis_client.set(key, value)
-    return True
-
-
-@task
-def set_request_last_run_timestamp(source: str, timestamp: str, mode: str = "prod"):
-    """Set the timestamp on Redis for the last time data was captured
-
-    Args:
-        source (str): Source API for the request
-        timestamp (str): Timestamp value to set on Redis
-        mode (str, optional): Whether to run in prod or dev. Defaults to "prod".
-
-    Returns:
-        bool: Whether timestamp was successfully set
-    """
-    redis_client = get_redis_client()
-    key = source
-    if mode == "dev":
-        key = f"{mode}.{key}"
-    # format timestamp to ignore fractions of seconds
-    timestamp = datetime.fromisoformat(timestamp)
-    timestamp = timestamp.strftime("%Y-%m-%d+%H:%M:%S%z")
-    value = {"last_run_timestamp": timestamp}
-    log(f"Setting {key} to {value} on Redis")
     redis_client.set(key, value)
     return True
 

--- a/pipelines/rj_smtr/utils.py
+++ b/pipelines/rj_smtr/utils.py
@@ -3,13 +3,11 @@
 General purpose functions for rj_smtr
 """
 
-from datetime import datetime, timedelta
 from pathlib import Path
 
 import basedosdados as bd
 from basedosdados import Table
 import pandas as pd
-import pendulum
 
 from pipelines.utils.utils import log
 from pipelines.utils.utils import (
@@ -165,42 +163,6 @@ def get_last_run_timestamp(dataset_id: str, table_id: str, mode: str = "prod"):
     except TypeError:
         return None
     return last_run_timestamp
-
-
-def get_request_date_range(source: str, mode: str = "prod"):
-    """Get date range for requesting SPPO data
-
-    Args:
-        source (str): Souce API for the request
-        mode (str, optional): Whethter running in prod or dev. Defaults to "prod".
-
-    Returns:
-        date_range: dict containing formatted strings for the request
-    """
-    redis_client = get_redis_client()
-    key = source
-    if mode == "dev":
-        key = f"{mode}.{source}"
-    runs = redis_client.get(key)
-    now_timestamp = pendulum.now(constants.TIMEZONE.value)
-    try:
-        last_run_timestamp = datetime.strptime(
-            runs["last_run_timestamp"], "%Y-%m-%d+%H:%M:%S%z"
-        )
-    except KeyError:
-        last_run_timestamp = now_timestamp - timedelta(minutes=1)
-    except TypeError:
-        last_run_timestamp = now_timestamp - timedelta(minutes=1)
-    except ValueError:
-        last_run_timestamp = now_timestamp - timedelta(minutes=1)
-
-    if now_timestamp - last_run_timestamp > timedelta(hours=1):
-        now_timestamp = last_run_timestamp + timedelta(hours=1)
-    date_range = {
-        "start": last_run_timestamp.strftime("%Y-%m-%d+%H:%M:%S"),
-        "end": now_timestamp.strftime("%Y-%m-%d+%H:%M:%S"),
-    }
-    return date_range
 
 
 def map_dict_keys(data: dict, mapping: dict) -> None:


### PR DESCRIPTION
Descrição:
- Adiciona uma checagem condicional sobre a resposta da API v2:
    - Quando a requisição resultou em um erro, a API retorna um dicionário simples com as keys `RetornoOK`, `DescricaoErro`, entre outras, ao passo que em requisições bem sucedidas, o resultado é uma lista de dicionários. Assim, o check captura a chave `DescricaoErro` e sobe para a tabela de logs, registrando essa captura como uma falha.
- Até o momento, o período máximo entre os parâmetros `dataInicial` e `dataFinal` na requisição é de 1h, portanto a função `pipelines/rj_smtr/utils.py :: get_request_date_range`  também foi alterada para, no caso de o intervalo ser maior, o flow utilizar como parâmetros para a requisição:
    - `dataInicial`: timestamp da ultima run
    - `dataFInal`: dataInicial + 1h
 - Por fim, adiciona a `timezone` às `timestamps` salvas no Redis, para fins da comparação citada acima se dar no fuso correto