### PR TITLE
[rj-smtr] feat: adiciona recaptura

### DIFF
--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -238,12 +238,12 @@ with Flow("SMTR - GPS SPPO Recapturas", code_owners=["caio", "fernanda"]) as rec
     recaptura.set_dependencies(task=status_dict, upstream_tasks=[filepath])
     recaptura.set_dependencies(task=LAST_TASK, upstream_tasks=[UPLOAD_CSV])
 
-materialize_sppo.storage = GCS(emd_constants.GCS_FLOWS_BUCKET.value)
-materialize_sppo.run_config = KubernetesRun(
+recaptura.storage = GCS(emd_constants.GCS_FLOWS_BUCKET.value)
+recaptura.run_config = KubernetesRun(
     image=emd_constants.DOCKER_IMAGE.value,
     labels=[emd_constants.RJ_SMTR_AGENT_LABEL.value],
 )
-materialize_sppo.schedule = every_hour
+recaptura.schedule = every_hour
 
 captura_sppo_v2.storage = GCS(emd_constants.GCS_FLOWS_BUCKET.value)
 captura_sppo_v2.run_config = KubernetesRun(

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -214,7 +214,7 @@ with Flow("SMTR - GPS SPPO Recapturas", code_owners=["caio", "fernanda"]) as rec
 
         UPLOAD_LOGS = upload_logs_to_bq.map(
             dataset_id=unmapped(dataset_id),
-            parent_table_id=unmapped("registros_test_recaptura"),
+            parent_table_id=unmapped(table_id),
             status_dict=status_dict,
         )
 
@@ -224,7 +224,7 @@ with Flow("SMTR - GPS SPPO Recapturas", code_owners=["caio", "fernanda"]) as rec
 
         UPLOAD_CSV = bq_upload.map(
             dataset_id=unmapped(dataset_id),
-            table_id=unmapped("registros_test_recaptura"),
+            table_id=unmapped(table_id),
             filepath=treated_filepath,
             raw_filepath=raw_filepath,
             file_dict=file_dict,

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/utils.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/utils.py
@@ -33,7 +33,7 @@ import pandas as pd
 from pipelines.rj_smtr.constants import constants
 
 
-def sppo_filters(frame: pd.DataFrame, version: int = 1):
+def sppo_filters(frame: pd.DataFrame, version: int = 1, recapture: bool = False):
     """Apply filters to dataframe
 
     Args:
@@ -49,6 +49,11 @@ def sppo_filters(frame: pd.DataFrame, version: int = 1):
     elif version == 2:
         filter_col = "datahoraenvio"
         time_delay = constants.GPS_SPPO_CAPTURE_DELAY_V2.value
+    if recapture:
+        server_mask = (frame["datahoraenvio"] - frame["datahoraservidor"]) <= timedelta(
+            minutes=constants.GPS_SPPO_RECAPTURE_DELAY_V2.value
+        )
+        frame = frame[server_mask]
 
     mask = (frame[filter_col] - frame["datahora"]).apply(
         lambda x: timedelta(seconds=0) <= x <= timedelta(minutes=time_delay)

--- a/pipelines/rj_smtr/constants.py
+++ b/pipelines/rj_smtr/constants.py
@@ -46,7 +46,7 @@ class constants(Enum):  # pylint: disable=c0103
     GPS_SPPO_TREATED_TABLE_ID = "gps_sppo"
     GPS_SPPO_CAPTURE_DELAY_V1 = 1
     GPS_SPPO_CAPTURE_DELAY_V2 = 60
-
+    GPS_SPPO_RECAPTURE_DELAY_V2 = 6
     # GPS BRT #
     GPS_BRT_API_BASE_URL = (
         "http://citgisbrj.tacom.srv.br:9977/gtfs-realtime-exporter/findAll/json"

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -335,20 +335,20 @@ def query_logs(
         list: containing timestamps for which the capture failed
 
     """
-    # AND
-    #         timestamp_captura
-    #         BETWEEN
-    #         DATETIME_SUB(
-    #             '{datetime_filter.strftime('%Y-%m-%d %H:%M:%S')}',
-    #             INTERVAL 3 HOUR
-    #         )
-    #         AND
-    #         '{datetime_filter.strftime('%Y-%m-%d %H:%M:%S')}'
     query = f"""
         SELECT *
         FROM rj-smtr.{dataset_id}.{table_id}_logs
         WHERE
             data = '{datetime_filter.date().isoformat()}'
+        AND
+            timestamp_captura
+            BETWEEN
+            DATETIME_SUB(
+                '{datetime_filter.strftime('%Y-%m-%d %H:%M:%S')}',
+                INTERVAL 1 HOUR
+            )
+            AND
+            '{datetime_filter.strftime('%Y-%m-%d %H:%M:%S')}'
         AND
             sucesso is False
         ORDER BY timestamp_captura


### PR DESCRIPTION
Changelog:
- Adiciona flow de recaptura dos dados em `pipelines.rj_smtr.br_rj_riodejaneiro_onibus_gps.flows`
    - Adiciona task `query_logs` as tasks gerais da smtr. Usada para checar os erros de captura na última hora
    - Adiciona novos parâmetros a todas as funções do flow de captura padrão, para que possam receber um `dict` como argumento, para executá-las dentro de um `map`,  o que permite a iteração item a item.
    - Expõe o argumento `timestamp` em `get_raw` que era definido dentro da função. Permite que as recapturas salvem os arquivos recapturados nas partições corretas no storage.
    - Adiciona o argumento `recapture` em `pre_treatment_br_rj_riodejaneiro_onibus_gps` para controlar a filtragem do dataframe em caso de recaptura (o mesmo argumento foi adicionado a `sppo_filters`).
    - A filtragem a ser feita em recapturas é a seguinte: `datahoraenvio` e `datahoraservidor` não podem ter um intervalo maior que 6 minutos entre si. Esse valor é controlado pela constante `pipelines.rj_smtr.constants.GPS_SPPO_RECAPTURE_DELAY_V2`
    -  Remove o schedule do flow de materialização e o passa para o flow de recaptura. Antes de toda materialização, buscamos os erros da hora anterior, se houver algum recapturamos e então criamos uma `flow_run` para a materialização
    - Ajusta as docstrings para dar conta dos novos argumentos e particularidades de uso das tasks gerais da smtr