### PR TITLE
[rj-smtr] fix: busca de `logs` na recaptura do sppo 

### DIFF
--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -320,7 +320,7 @@ def save_treated_local(file_path, mode="staging", dataframe=None, treated_status
 def query_logs(
     dataset_id: str,
     table_id: str,
-    datetime_filter=pendulum.now(constants.TIMEZONE.value),
+    datetime_filter=None,
 ):
     """Queries capture logs to check for errors
 
@@ -335,6 +335,10 @@ def query_logs(
         list: containing timestamps for which the capture failed
 
     """
+
+    if not datetime_filter:
+        datetime_filter = pendulum.now(constants.TIMEZONE.value)
+
     query = f"""
         SELECT *
         FROM rj-smtr.{dataset_id}.{table_id}_logs


### PR DESCRIPTION
Corrije datahora para busca de erros de captura em `registros_logs` (não estava variando para diferentes `runs`)