### PR TITLE
[smtr] fix: correção do ambiente `dev`

### DIFF
--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -60,9 +60,12 @@ def get_current_flow_labels() -> List[str]:
 
 @task
 def get_current_flow_mode(labels: List[str]) -> str:
+    """
+    Get the mode (prod/dev/staging) of the current flow.
+    """
     if labels[0].endswith("-dev"):
         return "dev"
-    elif labels[0].endswith("-staging"):
+    if labels[0].endswith("-staging"):
         return "staging"
     return "prod"
 

--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -59,6 +59,15 @@ def get_current_flow_labels() -> List[str]:
 
 
 @task
+def get_current_flow_mode(labels: List[str]) -> str:
+    if labels[0].endswith("-dev"):
+        return "dev"
+    elif labels[0].endswith("-staging"):
+        return "staging"
+    return "prod"
+
+
+@task
 def greater_than(value, compare_to) -> bool:
     """
     Returns True if value is greater than compare_to.


### PR DESCRIPTION
Mudanças para teste da pipeline em `dev` na `cloud`

**Como funciona?**

- A partir da `label` escolhida, determina-se o modo que será utilizado para rodar a pipeline
- Para pipelines que rodam com `dbt`, criamos a branch [`dev`](https://github.com/prefeitura-rio/queries-rj-smtr/tree/dev) que é utilizada para montar o dbt na cloud. Logo, os códigos do `dbt` que irão rodar na pipeline refletem o último commit nessa branch.