### PR TITLE
viagem_completa em schedules.py após inclusão de metadados

### DIFF
--- a/pipelines/rj_smtr/materialize_to_datario/schedules.py
+++ b/pipelines/rj_smtr/materialize_to_datario/schedules.py
@@ -22,7 +22,7 @@ smtr_materialize_to_datario_parameters = {
         "dataset_id": "transporte_rodoviario_municipal",
         "mode": "prod",
     },
-        "viagem_completa": {
+    "viagem_completa": {
         "dataset_id": "transporte_rodoviario_municipal",
         "mode": "prod",
     },

--- a/pipelines/rj_smtr/materialize_to_datario/schedules.py
+++ b/pipelines/rj_smtr/materialize_to_datario/schedules.py
@@ -22,6 +22,10 @@ smtr_materialize_to_datario_parameters = {
         "dataset_id": "transporte_rodoviario_municipal",
         "mode": "prod",
     },
+        "viagem_completa": {
+        "dataset_id": "transporte_rodoviario_municipal",
+        "mode": "prod",
+    },
 }
 
 smtr_materialize_to_datario_clocks = generate_execute_dbt_model_schedules(


### PR DESCRIPTION
Adicionados os dados de viagem completa em meta.dados.rio. e alterado schedules.py para incluir viagem completa.