### PR TITLE
[WIP] Adiciona captura do RHO pro SPPO

### DIFF
--- a/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/constants.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/constants.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+"""
+Constant values for the rj_smtr projects
+"""
+
+
+###############################################################################
+#
+# Esse é um arquivo onde podem ser declaratas constantes que serão usadas
+# pelo projeto br_rj_riodejaneiro_rdo.
+#
+# Por ser um arquivo opcional, pode ser removido sem prejuízo ao funcionamento
+# do projeto, caos não esteja em uso.
+#
+# Para declarar constantes, basta fazer conforme o exemplo abaixo:
+#
+# ```
+# class constants(Enum):
+#     """
+#     Constant values for the br_rj_riodejaneiro_rdo project
+#     """
+#     FOO = "bar"
+# ```
+#
+# Para usá-las, basta fazer conforme o exemplo abaixo:
+#
+# ```py
+# from pipelines.rj_smtr.br_rj_riodejaneiro_rdo.constants import constants
+# print(constants.FOO.value)
+# ```
+#
+###############################################################################
+
+from enum import Enum
+
+
+class constants(Enum):  # pylint: disable=c0103
+    """
+    Constant values for the br_rj_riodejaneiro_rdo project
+    """
+
+    RDO_PRE_TREATMENT_CONFIG = {
+        "SPPO": {
+            "RDO": {
+                "reindex_columns": [
+                    "operadora",
+                    "linha",
+                    "data_transacao",
+                    "tarifa_valor",
+                    "gratuidade_idoso",
+                    "gratuidade_especial",
+                    "gratuidade_estudante_federal",
+                    "gratuidade_estudante_estadual",
+                    "gratuidade_estudante_municipal",
+                    "universitario",
+                    "gratuito_rodoviario",
+                    "buc_1a_perna",
+                    "buc_2a_perna",
+                    "buc_receita",
+                    "buc_supervia_1a_perna",
+                    "buc_supervia_2a_perna",
+                    "buc_supervia_receita",
+                    "buc_van_1a_perna",
+                    "buc_van_2a_perna",
+                    "buc_van_receita",
+                    "buc_vlt_1a_perna",
+                    "buc_vlt_2a_perna",
+                    "buc_vlt_receita",
+                    "buc_brt_1a_perna",
+                    "buc_brt_2a_perna",
+                    "buc_brt_3a_perna",
+                    "buc_brt_receita",
+                    "buc_inter_1a_perna",
+                    "buc_inter_2a_perna",
+                    "buc_inter_receita",
+                    "buc_barcas_1a_perna",
+                    "buc_barcas_2a_perna",
+                    "buc_barcas_receita",
+                    "buc_metro_1a_perna",
+                    "buc_metro_2a_perna",
+                    "buc_metro_receita",
+                    "cartao",
+                    "receita_cartao",
+                    "especie_passageiro_transportado",
+                    "especie_receita",
+                    "registro_processado",
+                    "data_processamento",
+                    "linha_rcti",
+                ],
+                "divide_columns": "",
+                "reorder_columns": "",
+            },
+            "RHO": {
+                "reindex_columns": [
+                    "linha",
+                    "data_transacao",
+                    "hora_transacao",
+                    "total_gratuidades",
+                    "total_pagantes_especie",
+                    "total_pagantes_cartao",
+                    "registro_processado",
+                    "data_processamento",
+                    "operadora",
+                    "linha_rcti",
+                ],
+                "divide_columns": "",
+                "reorder_columns": "",
+            },
+        },
+        "STPL": {
+            "RDO": {
+                "reindex_columns": [
+                    "operadora",
+                    "linha",
+                    "tarifa_valor",
+                    "data_transacao",
+                    "gratuidade_idoso",
+                    "gratuidade_especial",
+                    "gratuidade_estudante_federal",
+                    "gratuidade_estudante_estadual",
+                    "gratuidade_estudante_municipal",
+                    "universitario",
+                    "buc_1a_perna",
+                    "buc_2a_perna",
+                    "buc_receita",
+                    "buc_supervia_1a_perna",
+                    "buc_supervia_2a_perna",
+                    "buc_supervia_receita",
+                    "buc_van_1a_perna",
+                    "buc_van_2a_perna",
+                    "buc_van_receita",
+                    "buc_brt_1a_perna",
+                    "buc_brt_2a_perna",
+                    "buc_brt_3a_perna",
+                    "buc_brt_receita",
+                    "buc_inter_1a_perna",
+                    "buc_inter_2a_perna",
+                    "buc_inter_receita",
+                    "buc_metro_1a_perna",
+                    "buc_metro_2a_perna",
+                    "buc_metro_receita",
+                    "cartao",
+                    "receita_cartao",
+                    "especie_passageiro_transportado",
+                    "especie_receita",
+                    "registro_processado",
+                    "data_processamento",
+                    "linha_rcti",
+                    "codigo",
+                ],
+                "reorder_columns": {"tarifa_valor": 3, "data_transacao": 2},
+                "divide_columns": [
+                    "tarifa_valor",
+                    "buc_receita",
+                    "buc_supervia_receita",
+                    "buc_van_receita",
+                    "buc_brt_receita",
+                    "buc_inter_receita",
+                    "buc_metro_receita",
+                    "receita_cartao",
+                    "especie_receita",
+                ],
+            },
+            "RHO": {
+                "reindex_columns": [
+                    "operadora",
+                    "linha",
+                    "data_transacao",
+                    "hora_transacao",
+                    "total_gratuidades",
+                    "total_pagantes",
+                    "codigo",
+                ],
+                "divide_columns": "",
+                "reorder_columns": "",
+            },
+        },
+    }

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/flows.py
@@ -57,8 +57,8 @@ Flows for br_rj_riodejaneiro_rdo
 #
 ###############################################################################
 
-from copy import deepcopy
-from prefect import Parameter, case
+# from copy import deepcopy
+from prefect import Parameter
 from prefect.run_configs import KubernetesRun
 from prefect.storage import GCS
 from pipelines.constants import constants as emd_constants

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/flows.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""
+Flows for br_rj_riodejaneiro_rdo
+"""
+
+###############################################################################
+#
+# Aqui é onde devem ser definidos os flows do projeto.
+# Cada flow representa uma sequência de passos que serão executados
+# em ordem.
+#
+# Mais informações sobre flows podem ser encontradas na documentação do
+# Prefect: https://docs.prefect.io/core/concepts/flows.html
+#
+# De modo a manter consistência na codebase, todo o código escrito passará
+# pelo pylint. Todos os warnings e erros devem ser corrigidos.
+#
+# Existem diversas maneiras de declarar flows. No entanto, a maneira mais
+# conveniente e recomendada pela documentação é usar a API funcional.
+# Em essência, isso implica simplesmente na chamada de funções, passando
+# os parâmetros necessários para a execução em cada uma delas.
+#
+# Também, após a definição de um flow, para o adequado funcionamento, é
+# mandatório configurar alguns parâmetros dele, os quais são:
+# - storage: onde esse flow está armazenado. No caso, o storage é o
+#   próprio módulo Python que contém o flow. Sendo assim, deve-se
+#   configurar o storage como o pipelines.rj_smtr
+# - run_config: para o caso de execução em cluster Kubernetes, que é
+#   provavelmente o caso, é necessário configurar o run_config com a
+#   imagem Docker que será usada para executar o flow. Assim sendo,
+#   basta usar constants.DOCKER_IMAGE.value, que é automaticamente
+#   gerado.
+# - schedule (opcional): para o caso de execução em intervalos regulares,
+#   deve-se utilizar algum dos schedules definidos em schedules.py
+#
+# Um exemplo de flow, considerando todos os pontos acima, é o seguinte:
+#
+# -----------------------------------------------------------------------------
+# from prefect import task
+# from prefect import Flow
+# from prefect.run_configs import KubernetesRun
+# from prefect.storage import GCS
+# from pipelines.constants import constants
+# from my_tasks import my_task, another_task
+# from my_schedules import some_schedule
+#
+# with Flow("my_flow") as flow:
+#     a = my_task(param1=1, param2=2)
+#     b = another_task(a, param3=3)
+#
+# flow.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+# flow.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
+# flow.schedule = some_schedule
+# -----------------------------------------------------------------------------
+#
+# Abaixo segue um código para exemplificação, que pode ser removido.
+#
+###############################################################################
+
+from copy import deepcopy
+from prefect import Parameter, case
+from prefect.run_configs import KubernetesRun
+from prefect.storage import GCS
+from pipelines.constants import constants as emd_constants
+from pipelines.rj_smtr.br_rj_riodejaneiro_rdo.tasks import (
+    get_file_paths_from_ftp,
+    download_and_save_local_from_ftp,
+    pre_treatment_br_rj_riodejaneiro_rdo,
+)
+from pipelines.rj_smtr.constants import constants
+from pipelines.rj_smtr.tasks import bq_upload
+
+# from pipelines.rj_smtr.br_rj_riodejaneiro_rdo.schedules import every_two_weeks
+from pipelines.utils.decorators import Flow
+
+with Flow(
+    "SMTR - Captura RDO - SPPO",
+    code_owners=["caio", "fernanda"],
+) as captura_sppo_rho:
+    transport_mode = Parameter("transport_mode", "SPPO")
+    report_type = Parameter("report_type", "RHO")
+    table_id = Parameter("table_id", constants.SPPO_RDO_TABLE_ID.value)
+
+    # Parse FTPS
+    file_info = get_file_paths_from_ftp(
+        transport_mode=transport_mode, report_type=report_type
+    )
+    updated_info = download_and_save_local_from_ftp(file_info=file_info)
+    treated_info = pre_treatment_br_rj_riodejaneiro_rdo(file_info=updated_info)
+    bq_upload(
+        dataset_id=constants.RDO_DATASET_ID.value,
+        table_id=table_id,
+        filepath=treated_info["treated_path"],
+        raw_filepath=treated_info["raw_path"],
+        partitions=treated_info["partitions"],
+    )
+
+
+captura_sppo_rho.storage = GCS(emd_constants.GCS_FLOWS_BUCKET.value)
+captura_sppo_rho.run_config = KubernetesRun(
+    image=emd_constants.DOCKER_IMAGE.value,
+    labels=[emd_constants.RJ_SMTR_DEV_AGENT_LABEL.value],
+)
+# flow.schedule = every_two_weeks
+
+# captura_sppo_rho = deepcopy(captura_sppo_rdo)
+# captura_sppo_rho.storage = GCS(emd_constants.GCS_FLOWS_BUCKET.value)
+# captura_sppo_rho.run_config = KubernetesRun(image=emd_constants.DOCKER_IMAGE.value)

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/implicit_ftp.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/implicit_ftp.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=C0114
 import ftplib
 import ssl
 
 
-class ImplicitFTP_TLS(ftplib.FTP_TLS):
+class ImplicitFtpTls(ftplib.FTP_TLS):
     """FTP_TLS subclass that automatically wraps sockets in SSL to support implicit FTPS."""
 
     def __init__(self, *args, **kwargs):

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/implicit_ftp.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/implicit_ftp.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+import ftplib
+import ssl
+
+
+class ImplicitFTP_TLS(ftplib.FTP_TLS):
+    """FTP_TLS subclass that automatically wraps sockets in SSL to support implicit FTPS."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._sock = None
+
+    @property
+    def sock(self):
+        """Return the socket."""
+        return self._sock
+
+    @sock.setter
+    def sock(self, value):
+        """When modifying the socket, ensure that it is ssl wrapped."""
+        if value is not None and not isinstance(value, ssl.SSLSocket):
+            value = self.context.wrap_socket(value)
+        self._sock = value

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/schedules.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/schedules.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""
+Schedules for br_rj_riodejaneiro_rdo
+"""
+
+###############################################################################
+#
+# Aqui é onde devem ser definidos os schedules para os flows do projeto.
+# Cada schedule indica o intervalo de tempo entre as execuções.
+# Um schedule pode ser definido para um ou mais flows.
+# Mais informações sobre schedules podem ser encontradas na documentação do
+# Prefect: https://docs.prefect.io/core/concepts/schedules.html
+#
+# De modo a manter consistência na codebase, todo o código escrito passará
+# pelo pylint. Todos os warnings e erros devem ser corrigidos.
+#
+# Os schedules devem ser definidos de acordo com a sintaxe do Prefect, como,
+# por exemplo, o seguinte (para executar a cada 1 minuto):
+#
+# -----------------------------------------------------------------------------
+# from datetime import timedelta, datetime
+# from prefect.schedules import Schedule
+# from prefect.schedules.clocks import IntervalClock
+# from pipelines.constants import constants
+#
+# minute_schedule = Schedule(
+#     clocks=[
+#         IntervalClock(
+#             interval=timedelta(minutes=1),
+#             start_date=datetime(2021, 1, 1),
+#             labels=[
+#                 constants.RJ_SMTR_AGENT_LABEL.value,
+#             ]
+#         ),
+#     ]
+# )
+# -----------------------------------------------------------------------------
+#
+# Vale notar que o parâmetro `labels` é obrigatório e deve ser uma lista com
+# apenas um elemento, correspondendo ao label do agente que será executado.
+# O label do agente é definido em `constants.py` e deve ter o formato
+# `RJ_SMTR_AGENT_LABEL`.
+#
+# Outro exemplo, para executar todos os dias à meia noite, segue abaixo:
+#
+# -----------------------------------------------------------------------------
+# from prefect import task
+# from datetime import timedelta
+# import pendulum
+# from prefect.schedules import Schedule
+# from prefect.schedules.clocks import IntervalClock
+# from pipelines.constants import constants
+#
+# every_day_at_midnight = Schedule(
+#     clocks=[
+#         IntervalClock(
+#             interval=timedelta(days=1),
+#             start_date=pendulum.datetime(
+#                 2021, 1, 1, 0, 0, 0, tz="America/Sao_Paulo"),
+#             labels=[
+#                 constants.K8S_AGENT_LABEL.value,
+#             ]
+#         )
+#     ]
+# )
+# -----------------------------------------------------------------------------
+#
+# Abaixo segue um código para exemplificação, que pode ser removido.
+#
+###############################################################################
+
+
+from datetime import timedelta, datetime
+from prefect.schedules import Schedule
+from prefect.schedules.clocks import IntervalClock
+from pipelines.constants import constants
+
+every_two_weeks = Schedule(
+    clocks=[
+        IntervalClock(
+            interval=timedelta(weeks=2),
+            start_date=datetime(2021, 1, 1),
+            labels=[
+                constants.RJ_SMTR_AGENT_LABEL.value,
+            ],
+        ),
+    ]
+)

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/tasks.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+"""
+Tasks for br_rj_riodejaneiro_rdo
+"""
+
+###############################################################################
+#
+# Aqui é onde devem ser definidas as tasks para os flows do projeto.
+# Cada task representa um passo da pipeline. Não é estritamente necessário
+# tratar todas as exceções que podem ocorrer durante a execução de uma task,
+# mas é recomendável, ainda que não vá implicar em  uma quebra no sistema.
+# Mais informações sobre tasks podem ser encontradas na documentação do
+# Prefect: https://docs.prefect.io/core/concepts/tasks.html
+#
+# De modo a manter consistência na codebase, todo o código escrito passará
+# pelo pylint. Todos os warnings e erros devem ser corrigidos.
+#
+# As tasks devem ser definidas como funções comuns ao Python, com o decorador
+# @task acima. É recomendado inserir type hints para as variáveis.
+#
+# Um exemplo de task é o seguinte:
+#
+# -----------------------------------------------------------------------------
+# from prefect import task
+#
+# @task
+# def my_task(param1: str, param2: int) -> str:
+#     """
+#     My task description.
+#     """
+#     return f'{param1} {param2}'
+# -----------------------------------------------------------------------------
+#
+# Você também pode usar pacotes Python arbitrários, como numpy, pandas, etc.
+#
+# -----------------------------------------------------------------------------
+# from prefect import task
+# import numpy as np
+#
+# @task
+# def my_task(a: np.ndarray, b: np.ndarray) -> str:
+#     """
+#     My task description.
+#     """
+#     return np.add(a, b)
+# -----------------------------------------------------------------------------
+#
+# Abaixo segue um código para exemplificação, que pode ser removido.
+#
+###############################################################################
+from datetime import datetime, timedelta
+from dateutil import parser
+import re
+import os
+
+import pandas as pd
+from pathlib import Path
+import pendulum
+from prefect import task
+
+from pipelines.rj_smtr.constants import constants
+from pipelines.rj_smtr.br_rj_riodejaneiro_rdo.constants import (
+    constants as rdo_constants,
+)
+from pipelines.rj_smtr.br_rj_riodejaneiro_rdo.utils import build_table_id, connect_ftp
+from pipelines.utils.utils import log
+
+
+@task
+def get_file_paths_from_ftp(transport_mode: str, report_type: str):
+    """
+    Search for files inside previous interval (days) from current date,
+    get filename and partitions (from filename) on FTP client.
+    """
+    # ftp_allowed_paths =   # TODO: add allowed paths to constants
+    execution_time = pendulum.now(constants.TIMEZONE.value)
+    # Define interval for date search
+    now = execution_time + timedelta(hours=11, minutes=30)
+    min_timestamp = (
+        now - timedelta(days=1)
+    ).timestamp()  # Saturday, January 8, 2022 2:30:00 PM
+    max_timestamp = now.timestamp()  # Sunday, January 9, 2022 2:30:00 PM
+    log(f"{execution_time} of type {type(execution_time)}")
+    # Connect to FTP & search files
+    ftp_client = connect_ftp()
+    files_updated_times = {
+        file: datetime.timestamp(parser.parse(info["modify"]))
+        for file, info in ftp_client.mlsd(transport_mode)
+    }
+    # Get files modified inside interval
+    for filename, file_mtime in files_updated_times.items():
+        if file_mtime >= min_timestamp and file_mtime < max_timestamp:
+            if filename[:3] == report_type:
+                log(
+                    f"""
+                    Found file
+                    - {filename}
+                    at folder
+                    - {transport_mode}
+                    with timestamp
+                    - {str(file_mtime)}"""
+                )
+                # Get date from file
+                date = re.findall("2\\d{3}\\d{2}\\d{2}", filename)[-1]
+
+                file_info = {
+                    "transport_mode": transport_mode,
+                    "report_type": report_type,
+                    "filename": filename.split(".")[0],
+                    "ftp_path": transport_mode + "/" + filename,
+                    "partitions": f"ano={date[:4]}/mes={date[4:6]}/dia={date[6:]}",
+                }
+                log(f"Create file info: {file_info}")
+    return file_info
+
+
+@task
+def download_and_save_local_from_ftp(file_info: dict):
+    """
+    Downloads file from FTP and saves to data/raw/<dataset_id>/<table_id>.
+    """
+    # table_id: str, kind: str, rho: bool = False, rdo: bool = True
+    dataset_id = constants.RDO_DATASET_ID.value
+    ftp_data = constants.FTP_DATA.value
+    base_path = (
+        f'{os.getcwd()}/{os.getenv("DATA_FOLDER", "data")}/{{bucket_mode}}/{dataset_id}'
+    )
+
+    table_id = build_table_id(  # mudar pra task
+        mode=file_info["transport_mode"], report_type=file_info["report_type"]
+    )
+
+    # Set general local path to save file (bucket_modes: raw or staging)
+    file_info[
+        "local_path"
+    ] = f"""{base_path}/{table_id}/{file_info["partitions"]}/{file_info['filename']}.{{file_ext}}"""
+    # Get raw data
+    file_info["raw_path"] = file_info["local_path"].format(
+        bucket_mode="raw", file_ext="txt"
+    )
+    Path(file_info["raw_path"]).parent.mkdir(parents=True, exist_ok=True)
+    # Get data from FTP - TODO: create get_raw() error alike
+    ftp_client = connect_ftp(
+        ftp_data["host"],
+        ftp_data["username"],
+        ftp_data["pwd"],  # TODO: add ftp_data to constants
+    )
+    ftp_client.retrbinary(
+        "RETR " + file_info["ftp_path"],
+        open(file_info["raw_path"], "wb").write,
+    )
+    ftp_client.quit()
+    # Get timestamp of download time
+    file_info["timestamp_captura"] = pendulum.now(constants.TIMEZONE.value).isoformat()
+
+    log(f"Timestamp captura is {file_info['timestamp_captura']}")
+    log(f"Update file info: {file_info}")
+    return file_info
+
+
+@task
+def pre_treatment_br_rj_riodejaneiro_rdo(
+    file_info: dict,
+    divide_columns_by: int = 100,
+):
+    config = rdo_constants.RDO_PRE_TREATMENT_CONFIG.value[file_info["transport_mode"]][
+        file_info["report_type"]
+    ]
+    # context.log.info(f"Config for ETL: {config}")
+    # Load data
+    df = pd.read_csv(file_info["raw_path"], header=None, delimiter=";", index_col=False)
+    log(f"Load csv from raw file:\n{df.head(5)}")
+    # Set column names for those already in the file
+    df.columns = config["reindex_columns"][: len(df.columns)]
+    log(f"Found reindex columns at config:\n{df.head(5)}")
+    # Treat column "codigo", add empty column if doesn't exist
+    if ("codigo" in df.columns) and (file_info["transport_mode"] == "STPL"):
+        df["codigo"] = df["codigo"].str.extract("(?:VAN)(\\d+)").astype(str)
+    else:
+        df["codigo"] = ""
+    # Order columns
+    # if config["reorder_columns"]:
+    #     ordered = [
+    #         config["reorder_columns"][col]
+    #         if col in config["reorder_columns"].keys()
+    #         else i
+    #         for i, col in enumerate(config["reindex_columns"])
+    #     ]
+    #     df = df[list(config["reindex_columns"][col] for col in ordered)]
+    # else:
+    df = df[config["reindex_columns"]]
+    # Add timestamp column
+    df["timestamp_captura"] = file_info["timestamp_captura"]
+    log(f"Added timestamp_captura: {file_info['timestamp_captura']}")
+    log(f"Before dividing df is\n{df.head(5)}")
+    # Divide columns by value
+    if config["divide_columns"]:
+        df[config["divide_columns"]] = df[config["divide_columns"]].apply(
+            lambda x: x / divide_columns_by, axis=1
+        )
+    # Save treated data
+    file_info["treated_path"] = file_info["local_path"].format(
+        bucket_mode="staging", file_ext="csv"
+    )
+    Path(file_info["treated_path"]).parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(file_info["treated_path"], index=False)
+    log(f'Saved treated data to: {file_info["treated_path"]}')
+    log(f"Updated file info is:\n{file_info}")
+    return file_info

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/tasks.py
@@ -121,7 +121,6 @@ def download_and_save_local_from_ftp(file_info: dict):
     """
     # table_id: str, kind: str, rho: bool = False, rdo: bool = True
     dataset_id = constants.RDO_DATASET_ID.value
-    ftp_data = constants.FTP_DATA.value
     base_path = (
         f'{os.getcwd()}/{os.getenv("DATA_FOLDER", "data")}/{{bucket_mode}}/{dataset_id}'
     )
@@ -140,11 +139,7 @@ def download_and_save_local_from_ftp(file_info: dict):
     )
     Path(file_info["raw_path"]).parent.mkdir(parents=True, exist_ok=True)
     # Get data from FTP - TODO: create get_raw() error alike
-    ftp_client = connect_ftp(
-        ftp_data["host"],
-        ftp_data["username"],
-        ftp_data["pwd"],  # TODO: add ftp_data to constants
-    )
+    ftp_client = connect_ftp()
     ftp_client.retrbinary(
         "RETR " + file_info["ftp_path"],
         open(file_info["raw_path"], "wb").write,

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/tasks.py
@@ -69,7 +69,9 @@ from pipelines.utils.utils import log
 
 
 @task
-def get_file_paths_from_ftp(transport_mode: str, report_type: str):
+def get_file_paths_from_ftp(
+    transport_mode: str, report_type: str, wait=None
+):  # pylint: disable=W0613
     """
     Search for files inside previous interval (days) from current date,
     get filename and partitions (from filename) on FTP client.
@@ -142,10 +144,11 @@ def download_and_save_local_from_ftp(file_info: dict):
     Path(file_info["raw_path"]).parent.mkdir(parents=True, exist_ok=True)
     # Get data from FTP - TODO: create get_raw() error alike
     ftp_client = connect_ftp()
-    ftp_client.retrbinary(
-        "RETR " + file_info["ftp_path"],
-        open(file_info["raw_path"], "wb").write,
-    )
+    with open(file_info["raw_path"], "wb") as raw_file:
+        ftp_client.retrbinary(
+            "RETR " + file_info["ftp_path"],
+            raw_file.write,
+        )
     ftp_client.quit()
     # Get timestamp of download time
     file_info["timestamp_captura"] = pendulum.now(constants.TIMEZONE.value).isoformat()

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/utils.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/utils.py
@@ -29,15 +29,19 @@ General purpose functions for the br_rj_riodejaneiro_rdo project
 # ```
 #
 ###############################################################################
-from pipelines.rj_smtr.br_rj_riodejaneiro_rdo.implicit_ftp import ImplicitFTP_TLS
+from pipelines.rj_smtr.br_rj_riodejaneiro_rdo.implicit_ftp import ImplicitFtpTls
 from pipelines.utils.utils import get_vault_secret
 from pipelines.rj_smtr.constants import constants
 
 
 def connect_ftp():
-    # TODO: usar get_vault_secret
+    """Connect to FTP
+
+    Returns:
+        ImplicitFTP_TLS: ftp client
+    """
     ftp_data = get_vault_secret(constants.RDO_SECRET_PATH.value)["data"]
-    ftp_client = ImplicitFTP_TLS()
+    ftp_client = ImplicitFtpTls()
     ftp_client.connect(host=ftp_data["host"], port=990)
     ftp_client.login(user=ftp_data["username"], passwd=ftp_data["pwd"])
     ftp_client.prot_p()
@@ -45,6 +49,16 @@ def connect_ftp():
 
 
 def build_table_id(mode: str, report_type: str):
+    """Build table_id based on which table is the target
+    of current flow run
+
+    Args:
+        mode (str): SPPO or STPL
+        report_type (str): RHO or RDO
+
+    Returns:
+        str: table_id
+    """
     if mode == "SPPO":
         if report_type == "RDO":
             table_id = constants.SPPO_RDO_TABLE_ID.value

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/utils.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_rdo/utils.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""
+General purpose functions for the br_rj_riodejaneiro_rdo project
+"""
+
+###############################################################################
+#
+# Esse é um arquivo onde podem ser declaratas funções que serão usadas
+# pelo projeto br_rj_riodejaneiro_rdo.
+#
+# Por ser um arquivo opcional, pode ser removido sem prejuízo ao funcionamento
+# do projeto, caos não esteja em uso.
+#
+# Para declarar funções, basta fazer em código Python comum, como abaixo:
+#
+# ```
+# def foo():
+#     """
+#     Function foo
+#     """
+#     print("foo")
+# ```
+#
+# Para usá-las, basta fazer conforme o exemplo abaixo:
+#
+# ```py
+# from pipelines.rj_smtr.br_rj_riodejaneiro_rdo.utils import foo
+# foo()
+# ```
+#
+###############################################################################
+from pipelines.rj_smtr.br_rj_riodejaneiro_rdo.implicit_ftp import ImplicitFTP_TLS
+from pipelines.utils.utils import get_vault_secret
+from pipelines.rj_smtr.constants import constants
+
+
+def connect_ftp():
+    # TODO: usar get_vault_secret
+    ftp_data = get_vault_secret(constants.RDO_SECRET_PATH.value)["data"]
+    ftp_client = ImplicitFTP_TLS()
+    ftp_client.connect(host=ftp_data["host"], port=990)
+    ftp_client.login(user=ftp_data["username"], passwd=ftp_data["pwd"])
+    ftp_client.prot_p()
+    return ftp_client
+
+
+def build_table_id(mode: str, report_type: str):
+    if mode == "SPPO":
+        if report_type == "RDO":
+            table_id = constants.SPPO_RDO_TABLE_ID.value
+        else:
+            table_id = constants.SPPO_RHO_TABLE_ID.value
+    if mode == "STPL":
+        # slice the string to get rid of V at end of
+        # STPL reports filenames
+        if report_type[:3] == "RDO":
+            table_id = constants.STPL_RDO_TABLE_ID.value
+        else:
+            table_id = constants.STPL_RHO_TABLE_ID.value
+    return table_id

--- a/pipelines/rj_smtr/constants.py
+++ b/pipelines/rj_smtr/constants.py
@@ -111,3 +111,11 @@ class constants(Enum):  # pylint: disable=c0103
             "key_column": "trip_id",
         },
     }
+    # RDO/RHO
+    FTP_ALLOWED_PATHS = ["SPPO", "STPL"]
+    RDO_SECRET_PATH = "rdo"
+    RDO_DATASET_ID = "br_rj_riodejaneiro_rdo"
+    SPPO_RDO_TABLE_ID = "rdo_registros_sppo"
+    SPPO_RHO_TABLE_ID = "rho_registros_sppo"
+    STPL_RDO_TABLE_ID = "rdo_registros_stpl"
+    STPL_RHO_TABLE_ID = "rho_registros_stpl"

--- a/pipelines/rj_smtr/constants.py
+++ b/pipelines/rj_smtr/constants.py
@@ -113,7 +113,7 @@ class constants(Enum):  # pylint: disable=c0103
     }
     # RDO/RHO
     FTP_ALLOWED_PATHS = ["SPPO", "STPL"]
-    RDO_SECRET_PATH = "rdo"
+    FTPS_SECRET_PATH = "smtr_rdo_ftps"
     RDO_DATASET_ID = "br_rj_riodejaneiro_rdo"
     SPPO_RDO_TABLE_ID = "rdo_registros_sppo"
     SPPO_RHO_TABLE_ID = "rho_registros_sppo"

--- a/pipelines/rj_smtr/schedules.py
+++ b/pipelines/rj_smtr/schedules.py
@@ -8,6 +8,7 @@ from pytz import timezone
 from prefect.schedules import Schedule
 from prefect.schedules.clocks import IntervalClock
 from pipelines.constants import constants as emd_constants
+from pipelines.rj_smtr.br_rj_riodejaneiro_rdo.utils import generate_ftp_schedules
 from pipelines.rj_smtr.constants import constants
 
 every_minute = Schedule(
@@ -78,3 +79,8 @@ every_day = Schedule(
         ),
     ]
 )
+
+ftp_clocks = generate_ftp_schedules(
+    interval_minutes=60, label=emd_constants.RJ_SMTR_DEV_AGENT_LABEL
+)
+ftp_schedule = Schedule(ftp_clocks)

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -509,8 +509,9 @@ def bq_upload(
     partitions = {partitions}, type = {type(partitions)}
     """
     )
-    if status["error"] is not None:
-        return status["error"]
+    if status:
+        if status["error"] is not None:
+            return status["error"]
 
     error = None
     try:

--- a/pipelines/utils/dump_url/tasks.py
+++ b/pipelines/utils/dump_url/tasks.py
@@ -91,7 +91,7 @@ def dump_files(
     file_path: str,
     partition_columns: List[str],
     save_path: str = ".",
-    chunksize: int = 10 ** 6,
+    chunksize: int = 10**6,
     build_json_dataframe: bool = False,
     dataframe_key_column: str = None,
 ) -> None:


### PR DESCRIPTION
Descrição:
PR para migração da pipeline de captura dos arquivos de RDO/RHO que hoje rodam no dagster. As funcionalidades são basicamente as mesmas, porém com alguma adaptação nas estruturas de saídas das funções para simplificar o código e adequar aos paradigmas do prefect. No primeiro commit, está sendo adicionada uma versão funcional para a captura do RHO do SPPO, única tabela que ainda não temos no BigQuery.
O flow é parametrizado de forma genérica para que possamos usar a mesma definição, apenas variando parâmetros, para as capturas do RDO pro SPPO e dos RHO/RDO do STPL.
TODO:
- [x] Adicionar schedules para os outros arquivos
- [ ] Ajustar os table_id's em `rj-smtr.constants`
- [x] Adicionar os secrets para conexão com FTP ao `vault`
- [ ] Definir a frequência com a qual cada `flow` será lançado
- [ ] Dimensionar limites e requisições de memórias para o deploy