### PR TITLE
[smtr][rir] Fix partitioning 

### DIFF
--- a/pipelines/rj_smtr/registros_ocr_rir/tasks.py
+++ b/pipelines/rj_smtr/registros_ocr_rir/tasks.py
@@ -18,23 +18,19 @@ def get_files_from_ftp(
     dump: bool = False, execution_time: str = None, wait=None
 ):  # pylint: disable=W0613
     """Search FTP for files created in the same minute as the
-        capture time.
+    capture time.
 
-        Args:
-            dump (bool, optional): if True will dump all files found on the FTP.
-            Defaults to False.
-            execution_time (str, optional): optionally, search for a file created
-            at a given minute. Defaults to None.
-            wait (optional): used to create an upstream dependency with a previous
-    <<<<<<< HEAD
-            task.
-    =======
-            task
-    >>>>>>> 27ef357f13ff332e10389b10b7ee712991f27599
+    Args:
+        dump (bool, optional): if True will dump all files found on the FTP.
+        Defaults to False.
+        execution_time (str, optional): optionally, search for a file created
+        at a given minute. Defaults to None.
+        wait (optional): used to create an upstream dependency with a previous
+        task.
 
-        Returns:
-            dict: 'capture' is a flag for skipping tasks if no files were found,
-            'file_info' is the info for processing the captured file
+    Returns:
+        dict: 'capture' is a flag for skipping tasks if no files were found,
+        'file_info' is the info for processing the captured file
     """
     if execution_time:
         execution_time = datetime.fromisoformat(execution_time) - timedelta(minutes=1)
@@ -62,7 +58,7 @@ def get_files_from_ftp(
                         {
                             "filename": file,
                             "created_time": created_time,
-                            "partitions": f"data={created_time.day}/hora={created_time.hour}",
+                            "partitions": f"data={created_time.date()}/hora={created_time.hour}",
                         }
                     )
         else:


### PR DESCRIPTION
A partição gerada para uma run com `dump=False` estava setada como apenas o dia da data de geração do arquivo. Porém, é mais interessante usarmos a data completa em isoformat, i.e. agora a tabela está sendo salva em `staging/dashboards/registros_ocr_rir/data=1/hora=14` em vez de `staging/dashboards/registros_ocr_rir/data=2022-09-01/hora=14`