### PR TITLE
[utils] feat: adiciona flow de notifcação de falhas

### DIFF
--- a/pipelines/utils/__init__.py
+++ b/pipelines/utils/__init__.py
@@ -9,3 +9,4 @@ from pipelines.utils.dump_url.flows import *
 from pipelines.utils.execute_dbt_model.flows import *
 from pipelines.utils.predict_flow.flows import *
 from pipelines.utils.whatsapp_bot.flows import *
+from pipelines.utils.notify.flows import *

--- a/pipelines/utils/custom.py
+++ b/pipelines/utils/custom.py
@@ -44,6 +44,7 @@ class CustomFlow(Flow):
         terminal_state_handler: Optional[
             Callable[["Flow", State, Set[State]], Optional[State]]
         ] = None,
+        secret_path: str = constants.EMD_DISCORD_WEBHOOK_SECRET_PATH.value,
         code_owners: Optional[List[str]] = None,
     ):
         super().__init__(
@@ -59,7 +60,7 @@ class CustomFlow(Flow):
             state_handlers=state_handlers,
             on_failure=partial(
                 notify_discord_on_failure,
-                secret_path=constants.EMD_DISCORD_WEBHOOK_SECRET_PATH.value,
+                secret_path=secret_path,
                 code_owners=code_owners,
             ),
             validate=validate,

--- a/pipelines/utils/notify/flows.py
+++ b/pipelines/utils/notify/flows.py
@@ -67,7 +67,7 @@ from pipelines.utils.notify.tasks import (
     post_to_discord_from_secret,
     query_flow_runs_by_state,
 )
-from pipelines.utils.notify.tasks import get_bool
+from pipelines.utils.tasks import get_bool
 
 from pipelines.utils.notify.schedules import smtr_every_fifteen_minutes
 from pipelines.utils.decorators import Flow

--- a/pipelines/utils/notify/flows.py
+++ b/pipelines/utils/notify/flows.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""
+Flows for notify
+"""
+
+###############################################################################
+#
+# Aqui é onde devem ser definidos os flows do projeto.
+# Cada flow representa uma sequência de passos que serão executados
+# em ordem.
+#
+# Mais informações sobre flows podem ser encontradas na documentação do
+# Prefect: https://docs.prefect.io/core/concepts/flows.html
+#
+# De modo a manter consistência na codebase, todo o código escrito passará
+# pelo pylint. Todos os warnings e erros devem ser corrigidos.
+#
+# Existem diversas maneiras de declarar flows. No entanto, a maneira mais
+# conveniente e recomendada pela documentação é usar a API funcional.
+# Em essência, isso implica simplesmente na chamada de funções, passando
+# os parâmetros necessários para a execução em cada uma delas.
+#
+# Também, após a definição de um flow, para o adequado funcionamento, é
+# mandatório configurar alguns parâmetros dele, os quais são:
+# - storage: onde esse flow está armazenado. No caso, o storage é o
+#   próprio módulo Python que contém o flow. Sendo assim, deve-se
+#   configurar o storage como o pipelines.utils
+# - run_config: para o caso de execução em cluster Kubernetes, que é
+#   provavelmente o caso, é necessário configurar o run_config com a
+#   imagem Docker que será usada para executar o flow. Assim sendo,
+#   basta usar constants.DOCKER_IMAGE.value, que é automaticamente
+#   gerado.
+# - schedule (opcional): para o caso de execução em intervalos regulares,
+#   deve-se utilizar algum dos schedules definidos em schedules.py
+#
+# Um exemplo de flow, considerando todos os pontos acima, é o seguinte:
+#
+# -----------------------------------------------------------------------------
+# from prefect import task
+# from prefect import Flow
+# from prefect.run_configs import KubernetesRun
+# from prefect.storage import GCS
+# from pipelines.constants import constants
+# from my_tasks import my_task, another_task
+# from my_schedules import some_schedule
+#
+# with Flow("my_flow") as flow:
+#     a = my_task(param1=1, param2=2)
+#     b = another_task(a, param3=3)
+#
+# flow.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+# flow.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
+# flow.schedule = some_schedule
+# -----------------------------------------------------------------------------
+#
+# Abaixo segue um código para exemplificação, que pode ser removido.
+#
+###############################################################################
+
+from prefect import case, Parameter
+from prefect.run_configs import KubernetesRun
+from prefect.storage import GCS
+from pipelines.constants import constants
+from pipelines.rj_escritorio.cleanup.tasks import get_prefect_client
+from pipelines.utils.notify.tasks import (
+    format_failed_runs,
+    post_to_discord_from_secret,
+    query_flow_runs_by_state,
+)
+from pipelines.utils.notify.tasks import get_bool
+
+from pipelines.utils.notify.schedules import smtr_every_fifteen_minutes
+from pipelines.utils.decorators import Flow
+
+with Flow(
+    "my_flow",
+    code_owners=[
+        "@your-discord-username",
+    ],
+) as discord_batch_notify:
+    # SETUP
+    prefix = Parameter("prefix", default=None)
+    query_interval = Parameter("query_interval", default=dict(hours=1))
+    datetime_filter = Parameter("datetime_filter", default=None)
+    webhook_secret_path = Parameter("webhook_secret_path", default=None)
+
+    client = get_prefect_client()
+    response = query_flow_runs_by_state(
+        _client=client,
+        prefix=prefix,
+        interval=query_interval,
+        datetime_filter=datetime_filter,
+    )
+    with case(get_bool(response), True):
+        message = format_failed_runs(response)
+        post_to_discord_from_secret(
+            message=message, webhook_secret_path=webhook_secret_path
+        )
+
+discord_batch_notify.storage = GCS(constants.GCS_FLOWS_BUCKET.value)
+discord_batch_notify.run_config = KubernetesRun(image=constants.DOCKER_IMAGE.value)
+discord_batch_notify.schedule = smtr_every_fifteen_minutes

--- a/pipelines/utils/notify/schedules.py
+++ b/pipelines/utils/notify/schedules.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""
+Schedules for notify
+"""
+
+###############################################################################
+#
+# Aqui é onde devem ser definidos os schedules para os flows do projeto.
+# Cada schedule indica o intervalo de tempo entre as execuções.
+# Um schedule pode ser definido para um ou mais flows.
+# Mais informações sobre schedules podem ser encontradas na documentação do
+# Prefect: https://docs.prefect.io/core/concepts/schedules.html
+#
+# De modo a manter consistência na codebase, todo o código escrito passará
+# pelo pylint. Todos os warnings e erros devem ser corrigidos.
+#
+# Os schedules devem ser definidos de acordo com a sintaxe do Prefect, como,
+# por exemplo, o seguinte (para executar a cada 1 minuto):
+#
+# -----------------------------------------------------------------------------
+# from datetime import timedelta, datetime
+# from prefect.schedules import Schedule
+# from prefect.schedules.clocks import IntervalClock
+# from pipelines.constants import constants
+#
+# minute_schedule = Schedule(
+#     clocks=[
+#         IntervalClock(
+#             interval=timedelta(minutes=1),
+#             start_date=datetime(2021, 1, 1),
+#             labels=[
+#                 constants.UTILS_AGENT_LABEL.value,
+#             ]
+#         ),
+#     ]
+# )
+# -----------------------------------------------------------------------------
+#
+# Vale notar que o parâmetro `labels` é obrigatório e deve ser uma lista com
+# apenas um elemento, correspondendo ao label do agente que será executado.
+# O label do agente é definido em `constants.py` e deve ter o formato
+# `UTILS_AGENT_LABEL`.
+#
+# Outro exemplo, para executar todos os dias à meia noite, segue abaixo:
+#
+# -----------------------------------------------------------------------------
+# from prefect import task
+# from datetime import timedelta
+# import pendulum
+# from prefect.schedules import Schedule
+# from prefect.schedules.clocks import IntervalClock
+# from pipelines.constants import constants
+#
+# every_day_at_midnight = Schedule(
+#     clocks=[
+#         IntervalClock(
+#             interval=timedelta(days=1),
+#             start_date=pendulum.datetime(
+#                 2021, 1, 1, 0, 0, 0, tz="America/Sao_Paulo"),
+#             labels=[
+#                 constants.K8S_AGENT_LABEL.value,
+#             ]
+#         )
+#     ]
+# )
+# -----------------------------------------------------------------------------
+#
+# Abaixo segue um código para exemplificação, que pode ser removido.
+#
+###############################################################################
+
+
+from datetime import timedelta, datetime
+from prefect.schedules import Schedule
+from prefect.schedules.clocks import IntervalClock
+from pipelines.constants import constants
+from pipelines.rj_smtr.constants import constants as smtr_constants
+
+smtr_every_fifteen_minutes = Schedule(
+    clocks=[
+        IntervalClock(
+            interval=timedelta(minutes=15),
+            start_date=datetime(2021, 1, 1),
+            labels=[
+                constants.RJ_SMTR_AGENT_LABEL.value,
+            ],
+            parameter_defaults={
+                "prefix": "smtr",
+                "query_interval": dict(minutes=10),
+                "webhook_secret_path": smtr_constants.CRITICAL_SECRET_PATH.value,
+            },
+        ),
+    ]
+)

--- a/pipelines/utils/notify/tasks.py
+++ b/pipelines/utils/notify/tasks.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+"""
+Tasks for graphql
+"""
+
+###############################################################################
+#
+# Aqui é onde devem ser definidas as tasks para os flows do projeto.
+# Cada task representa um passo da pipeline. Não é estritamente necessário
+# tratar todas as exceções que podem ocorrer durante a execução de uma task,
+# mas é recomendável, ainda que não vá implicar em  uma quebra no sistema.
+# Mais informações sobre tasks podem ser encontradas na documentação do
+# Prefect: https://docs.prefect.io/core/concepts/tasks.html
+#
+# De modo a manter consistência na codebase, todo o código escrito passará
+# pelo pylint. Todos os warnings e erros devem ser corrigidos.
+#
+# As tasks devem ser definidas como funções comuns ao Python, com o decorador
+# @task acima. É recomendado inserir type hints para as variáveis.
+#
+# Um exemplo de task é o seguinte:
+#
+# -----------------------------------------------------------------------------
+# from prefect import task
+#
+# @task
+# def my_task(param1: str, param2: int) -> str:
+#     """
+#     My task description.
+#     """
+#     return f'{param1} {param2}'
+# -----------------------------------------------------------------------------
+#
+# Você também pode usar pacotes Python arbitrários, como numpy, pandas, etc.
+#
+# -----------------------------------------------------------------------------
+# from prefect import task
+# import numpy as np
+#
+# @task
+# def my_task(a: np.ndarray, b: np.ndarray) -> str:
+#     """
+#     My task description.
+#     """
+#     return np.add(a, b)
+# -----------------------------------------------------------------------------
+#
+# Abaixo segue um código para exemplificação, que pode ser removido.
+#
+###############################################################################
+from datetime import datetime, timedelta
+from typing import Any, Dict
+from pytz import timezone
+from prefect import task, client
+from pipelines.utils.utils import get_vault_secret, send_discord_message
+
+
+@task
+def query_flow_runs_by_state(
+    _client: client.Client,
+    prefix: str,
+    state: str = "Failed",
+    interval: dict = None,
+    datetime_filter: str = None,
+):
+    """
+    Query GraphQL API for failed flow runs. The query searches
+    for flows with the given `prefix` and filter runs from the
+    `datetime.now()` time up to the specified `interval` before.
+    This utility can be used to query for any state by changing
+    `state` arg.
+    Args:
+        client(prefect.client.Client): object used to interact with
+        prefect backend.
+        prefix(str): prefix to use in the query.
+        state(Optional, str): flow run state to query for. Defaults
+        to "Failed".
+        interval(Optional, dict): dict of kwargs to pass to datetime.timedelta.
+        Defaults to {"hours": 1},
+        datetime_filter: str = None):
+    Returns:
+        dict: the response for the query
+
+    """
+    if datetime_filter:
+        max_start_time = datetime.fromisoformat(datetime_filter)
+    else:
+        max_start_time = datetime.now(tz=timezone("America/Sao_Paulo"))
+    if not interval:
+        interval = dict(hours=1)
+    min_start_time = max_start_time - timedelta(**interval)
+    if not prefix.endswith("%"):
+        prefix += "%"
+    query = """
+        query (
+            $prefix:String!,
+            $state:String!,
+            $min_start_time:timestamptz!,
+            $max_start_time:timestamptz)
+        {
+            flow(
+                where:
+                {
+                    name: { _ilike:$prefix },
+                    flow_runs: {
+                    start_time: {_lte: $max_start_time, _gte:$min_start_time},
+                    state: {_eq: $state }
+                    }
+                }
+            ){
+                name,
+                project{
+                name
+                },
+                flow_runs(
+                    where:
+                    {
+                    start_time: {_lte: $max_start_time, _gte:$min_start_time},
+                    state: {_eq: $state }
+                    }
+                    order_by:{name:asc, labels:asc}
+                }
+                ){
+                    name,
+                    scheduled_start_time,
+                    state,
+                    labels,
+                    state_message
+                }
+            }
+        }
+    """
+    response = _client.graphql(
+        query=query,
+        variables=dict(
+            prefix=prefix,
+            state=state,
+            min_start_time=min_start_time,
+            max_start_time=max_start_time,
+        ),
+    )["data"]
+    return response
+
+
+@task
+def format_failed_runs(response: Dict, min_failures: int = 10):
+    """
+    Format data received from query as a discord message.
+    If the query finds more than `min_failures`, adds a
+    @here marker to the message.
+    Args:
+        response(dict): data received from a query to GraphQL
+        API.
+        min_failures(Optional, int): minimum number of failures
+        to add the marker @here
+    Returns:
+        str: the message to post
+    """
+    base_msg = "Falhas na execução dos flows na ultima hora:\n"
+    for flow in response["flow"]:
+        flow_msg = f"""
+        O Flow `{flow['name']}` registrado em `{flow['project']['name']}`
+        teve as seguintes falhas:\n
+        """
+        if len(flow["flow_runs"]) >= min_failures:
+            flow_msg += "---Critical---\n@here\n"
+        for run in flow["flow_runs"]:
+            flow_msg += f"""
+            ---------------------------------
+            run_name: {run['name']}
+            scheduled_start_time: {run['scheduled_start_time']}
+            label: {run['labels'][0]}
+            error: {run['state_message']}
+            ---------------------------------\n
+            """
+        base_msg += flow_msg
+    return base_msg
+
+
+@task
+def post_to_discord_from_secret(message: str, webhook_secret_path: str):
+    """Post message to a discord channel by fetching the webhook_url
+    from a secret
+
+    Args:
+        message (str): message to post
+        webhook_secret_path (str): secret path to get the url.
+        Should be defined with a key `url`.
+    """
+    webhook_url = get_vault_secret(webhook_secret_path)["url"]
+    return send_discord_message(message=message, webhook_url=webhook_url)
+
+
+@task
+def get_bool(value: Any):
+    """get boolean evaluation for the value
+    Returns:
+        bool: evaluation for the value
+    """
+    return bool(value)

--- a/pipelines/utils/notify/tasks.py
+++ b/pipelines/utils/notify/tasks.py
@@ -189,12 +189,3 @@ def post_to_discord_from_secret(message: str, webhook_secret_path: str):
     """
     webhook_url = get_vault_secret(webhook_secret_path)["url"]
     return send_discord_message(message=message, webhook_url=webhook_url)
-
-
-@task
-def get_bool(value: Any):
-    """get boolean evaluation for the value
-    Returns:
-        bool: evaluation for the value
-    """
-    return bool(value)

--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -71,6 +71,15 @@ def get_current_flow_mode(labels: List[str]) -> str:
 
 
 @task
+def get_bool(value: Any):
+    """get boolean evaluation for the value
+    Returns:
+        bool: evaluation for the value
+    """
+    return bool(value)
+
+
+@task
 def greater_than(value, compare_to) -> bool:
     """
     Returns True if value is greater than compare_to.


### PR DESCRIPTION
Descrição:
Adiciona um novo projeto `notify` aos utils gerais. O `flow` utiliza o client do Prefect para fazer uma query ao GraphQL e verificar as runs que falharam dentro de um intervalo de tempo especificado. Para tal, também adiciona uma task `get_bool` às tasks do utils, melhorando o controle de fluxo no uso de `case`s. No momento, a task `get_prefect_client` usada no flow, ainda está dentro do projeto de `cleanup ` do escritório, mas poderia ser passada para o utils também.
Aproveitando as modificações relacionadas a notificações, também expõe o parâmetro `secret_path` utilizado na definição do `CustomFlow` para que se possa direcionar as notificações a canais diferentes. É possível realizar mudanças no callback `notify_discord_on_failure` para que sempre notifique o canal do Prefect do escritório em conjunto com o envio da notificação para o canal da SMTR, por exemplo.

Changelog:
- Adiciona projeto `notify` ao utils:
    - tasks.py
    - flows.py
    - schedules.py
- `pipelines.utils.tasks`: adiciona task `get_bool`
- `pipelines.utils.custom`: expõe o parâmetro `secret_path` no construtor do CustomFlow