### PR TITLE
[smtr][materialize] Melhora comportamento de materialização e upload

### DIFF
--- a/pipelines/rj_smtr/constants.py
+++ b/pipelines/rj_smtr/constants.py
@@ -47,6 +47,7 @@ class constants(Enum):  # pylint: disable=c0103
     GPS_SPPO_CAPTURE_DELAY_V1 = 1
     GPS_SPPO_CAPTURE_DELAY_V2 = 60
     GPS_SPPO_RECAPTURE_DELAY_V2 = 6
+    GPS_SPPO_MATERIALIZE_DELAY_HOURS = 1
     # GPS BRT #
     GPS_BRT_SECRET_PATH = "brt_api"
     GPS_BRT_DATASET_ID = "br_rj_riodejaneiro_veiculos"
@@ -64,6 +65,7 @@ class constants(Enum):  # pylint: disable=c0103
         "nomeLinha": "vista",
         "inicio_viagem": "timestamp_inicio_viagem",
     }
+    GPS_BRT_MATERIALIZE_DELAY_HOURS = 0
 
     # SIGMOB (GTFS) #
     SIGMOB_GET_REQUESTS_TIMEOUT = 60

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -519,6 +519,7 @@ def upload_logs_to_bq(
     parent_table_id: str,
     timestamp: str,
     error: str = None,
+    previous_error: str = None,
     recapture: bool = False,
 ):
     """
@@ -542,26 +543,18 @@ def upload_logs_to_bq(
     )
     filepath.parent.mkdir(exist_ok=True, parents=True)
     # Create dataframe to be uploaded
-    if recapture is True:
+    if not error and recapture is True:
         # if the recapture is succeeded, update the column erro
-        if error is None:
-            dataframe = pd.DataFrame(
-                {
-                    "timestamp_captura": [timestamp],
-                    "sucesso": [True],
-                    "erro": ["[recapturado]"],
-                }
-            )
-        # if any iteration of the recapture fails, upload logs with error
-        else:
-            dataframe = pd.DataFrame(
-                {
-                    "timestamp_captura": [timestamp],
-                    "sucesso": [error is None],
-                    "erro": [f"[recapturado] {error}"],
-                }
-            )
+        dataframe = pd.DataFrame(
+            {
+                "timestamp_captura": [timestamp],
+                "sucesso": [True],
+                "erro": [f"[recapturado]{previous_error}"],
+            }
+        )
+        log(f"Recapturing {timestamp} with previous error:\n{error}")
     else:
+        # not recapturing or error during flow execution
         dataframe = pd.DataFrame(
             {
                 "timestamp_captura": [timestamp],

--- a/pipelines/rj_smtr/utils.py
+++ b/pipelines/rj_smtr/utils.py
@@ -36,7 +36,9 @@ def log_critical(message: str, secret_path: str = constants.CRITICAL_SECRET_PATH
     return send_discord_message(message=message, webhook_url=url)
 
 
-def create_or_append_table(dataset_id, table_id, path):
+def create_or_append_table(
+    dataset_id: str, table_id: str, path: str, partitions: str = None
+):
     """Conditionally create table or append data to its relative GCS folder.
 
     Args:
@@ -47,8 +49,9 @@ def create_or_append_table(dataset_id, table_id, path):
     tb_obj = Table(table_id=table_id, dataset_id=dataset_id)
     if not tb_obj.table_exists("staging"):
         log("Table does not exist in STAGING, creating table...")
+        dirpath = path.split(partitions)[0]
         tb_obj.create(
-            path=path,
+            path=dirpath,
             if_table_exists="pass",
             if_storage_data_exists="replace",
             if_table_config_exists="replace",
@@ -56,7 +59,9 @@ def create_or_append_table(dataset_id, table_id, path):
         log("Table created in STAGING")
     else:
         log("Table already exists in STAGING, appending to it...")
-        tb_obj.append(filepath=path, if_exists="replace", timeout=600)
+        tb_obj.append(
+            filepath=path, if_exists="replace", timeout=600, partitions=partitions
+        )
         log("Appended to table on STAGING successfully.")
 
 


### PR DESCRIPTION
closes https://github.com/prefeitura-rio/pipelines/issues/191 , https://github.com/prefeitura-rio/pipelines/issues/192

## Descrição

Em vista dos testes da rematerialização usando `create_flow_run`, cujos resultados foram insatisfatórios, este PR traz as mudanças propostas em #168, porém mantendo o paradigma de recapturas usando o método `.map` das tasks.
As melhorias propostas são:

### FLOWS ###
- `materialize_brt`: adiciona ao fluxo as tasks `get_current_flow_labels` e `get_current_flow_mode` para controle de execuções em dev/prod, substituindo os hardcodes de "prod" que estavam presentes na versão anterior
- `captura_sppo_v2`: adiciona o argumento `timestamp` à instância de `create_api_onibus_url` dentro do flow, a qual nunca recebia uma timestamp
- `recapturas/materialize_sppo`: adiciona parâmetro `materialize` ao fluxo, permitindo executar recapturas sem dar _trigger na materialização, útil para testes e para possível necessidade de recaptura manual, para evitar modificar os valores de `last_run_timestamp` salvos no Redis.

### TASKS ###
- `get_materialization_date_range`: expõe um argumento `delay_hours` para parametrizar as diferentes materializações gerenciadas no Prefect, permitindo um maior controle dos intervalos de materialização, além de mudar a parametrização para o seguinte esquema:
    - `date_range_start`: `last_run`, `date_range_end`: `now_ts  - delay_hours
-  `query_logs`: aumenta o número de saídas da task para 3:
    - `errors`: flag que indica se é necessário realizar uma recaptura
    - `timestamps`: timestamps para serem recapturadas
    - `previous_errors`: erros que ocorreram na captura original, causando a necessidade de recaptura
- `upload_logs_to_bq`: adiciona o comportamento necessário para lidar com os erros originais no caso de recapturas, parametriza o número máximo de recapturas a serem realizadas pelo argumento `max_recaptures`
- `create_or_append_table`: melhora o comportamento do upload em geral. Foi identificado um comportamento durante a recaptura no qual, a cada timestamp iterada, a função subia todas as partições salvas localmente, ocasionando lentidão desnecessária. Expondo o argumento `partitions`, podemos fazer o upload de apenas um arquivo por iteração dentro do `.map`. A mudança introduzida no bloco de criação da tabela (pipelines/rj_smtr/utils.py L52) foi feita para que, quando for necessário criar uma tabela, as partições sejam identificadas automaticamente pelo pacote da BD+