### PR TITLE
[smtr][rir] Desliga schedule de captura do ftp da CET-Rio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pipelines 
+# Pipelines
 
 Este repositório contém fluxos de captura e subida de dados no datalake
 da Prefeitura do Rio de Janeiro. O repositório é gerido pelo Escritório

--- a/pipelines/rj_smtr/registros_ocr_rir/flows.py
+++ b/pipelines/rj_smtr/registros_ocr_rir/flows.py
@@ -16,7 +16,7 @@ from pipelines.rj_smtr.registros_ocr_rir.tasks import (
 )
 from pipelines.rj_smtr.tasks import bq_upload, get_current_timestamp
 
-from pipelines.rj_smtr.schedules import every_minute
+# from pipelines.rj_smtr.schedules import every_minute
 from pipelines.utils.decorators import Flow
 from pipelines.utils.tasks import rename_current_flow_run_now_time
 

--- a/pipelines/rj_smtr/registros_ocr_rir/flows.py
+++ b/pipelines/rj_smtr/registros_ocr_rir/flows.py
@@ -55,4 +55,4 @@ captura_ocr.run_config = KubernetesRun(
     image=emd_constants.DOCKER_IMAGE.value,
     labels=[emd_constants.RJ_SMTR_AGENT_LABEL.value],
 )
-captura_ocr.schedule = every_minute
+# captura_ocr.schedule = every_minute


### PR DESCRIPTION
Descrição:
o flow não será usado por enquanto, por isso desligamos o schedule