### PR TITLE
[smtr][subsidio_sppo] fix: timezones de datas

### DIFF
--- a/pipelines/rj_smtr/projeto_subsidio_sppo/tasks.py
+++ b/pipelines/rj_smtr/projeto_subsidio_sppo/tasks.py
@@ -4,11 +4,10 @@ Tasks for projeto_subsidio_sppo
 """
 
 from typing import List
-import datetime
 import pandas as pd
 from prefect import task
 
-from pipelines.utils.tasks import log
+from pipelines.utils.tasks import log, get_now_date
 
 
 @task
@@ -17,7 +16,7 @@ def get_run_dates(date_range_start: str, date_range_end: str) -> List:
     Generates a list of dates between date_range_start and date_range_end.
     """
     if (date_range_start is False) or (date_range_end is False):
-        dates = [{"run_date": datetime.date.today().strftime("%Y-%m-%d")}]
+        dates = [{"run_date": get_now_date.run()}]
     else:
         dates = [
             {"run_date": d.strftime("%Y-%m-%d")}


### PR DESCRIPTION
* Ajuste da task `get_run_dates` para utilizar a data atual considerando a timezone (estava considerado UTC);
* Teste do flow `subsidio_sppo_preprod`. Em funcionamento com ou sem parâmetros.