### PR TITLE
[smtr][viagem_sppo] Alteração de parâmetros de datas para publicação no datario

### DIFF
--- a/pipelines/rj_smtr/materialize_to_datario/flows.py
+++ b/pipelines/rj_smtr/materialize_to_datario/flows.py
@@ -39,7 +39,7 @@ smtr_materialize_to_datario_viagem_sppo_parameters = {
     "dataset_id": "transporte_rodoviario_municipal",
     "table_id": "viagem_onibus",
     "mode": "prod",
-    "dbt_model_parameters": {"date_range_end": get_now_date.run()},
+    "dbt_model_parameters": {"date_range_end": get_now_date.run(), "date_range_start": None},
 }
 
 smtr_materialize_to_datario_viagem_sppo_flow = set_default_parameters(

--- a/pipelines/rj_smtr/materialize_to_datario/flows.py
+++ b/pipelines/rj_smtr/materialize_to_datario/flows.py
@@ -39,7 +39,7 @@ smtr_materialize_to_datario_viagem_sppo_parameters = {
     "dataset_id": "transporte_rodoviario_municipal",
     "table_id": "viagem_onibus",
     "mode": "prod",
-    "dbt_model_parameters": {"run_date": get_now_date.run()},
+    "dbt_model_parameters": {"date_range_end": get_now_date.run()},
 }
 
 smtr_materialize_to_datario_viagem_sppo_flow = set_default_parameters(

--- a/pipelines/rj_smtr/materialize_to_datario/flows.py
+++ b/pipelines/rj_smtr/materialize_to_datario/flows.py
@@ -39,7 +39,10 @@ smtr_materialize_to_datario_viagem_sppo_parameters = {
     "dataset_id": "transporte_rodoviario_municipal",
     "table_id": "viagem_onibus",
     "mode": "prod",
-    "dbt_model_parameters": {"date_range_end": get_now_date.run(), "date_range_start": None},
+    "dbt_model_parameters": {
+        "date_range_end": get_now_date.run(),
+        "date_range_start": None,
+    },
 }
 
 smtr_materialize_to_datario_viagem_sppo_flow = set_default_parameters(

--- a/pipelines/rj_smtr/projeto_subsidio_sppo/flows.py
+++ b/pipelines/rj_smtr/projeto_subsidio_sppo/flows.py
@@ -136,7 +136,7 @@ with Flow(
             "dataset_id": "transporte_rodoviario_municipal",
             "table_id": "viagem_onibus",
             "mode": "prod",
-            "dbt_model_parameters": dict(run_date=run_date),
+            "dbt_model_parameters": dict(date_range_end=run_date),
         },
     )
 


### PR DESCRIPTION
Alteração de parâmetros do flow `smtr_materialize_to_datario_viagem_sppo_flow`. Adicionado parâmetro opcional `date_range_start` e substituído o `run_date` pelo `date_range_end`.

A alteração dos parâmetros não infere nos flows, haja vista o parâmetro ser opcional para uso quando necessário.