### PR TITLE
[smtr][smtr_materialize_to_datario_viagem_sppo] Ajusta parâmetro padrão date_range_end

### DIFF
--- a/pipelines/rj_smtr/materialize_to_datario/flows.py
+++ b/pipelines/rj_smtr/materialize_to_datario/flows.py
@@ -12,7 +12,7 @@ from pipelines.constants import constants
 
 from pipelines.utils.execute_dbt_model.flows import utils_run_dbt_model_flow
 from pipelines.utils.utils import set_default_parameters
-from pipelines.utils.tasks import get_now_date
+from pipelines.utils.tasks import get_yesterday
 
 from pipelines.rj_smtr.materialize_to_datario.schedules import (
     smtr_materialize_to_datario_daily_schedule,
@@ -40,7 +40,7 @@ smtr_materialize_to_datario_viagem_sppo_parameters = {
     "table_id": "viagem_onibus",
     "mode": "prod",
     "dbt_model_parameters": {
-        "date_range_end": get_now_date.run(),
+        "date_range_end": get_yesterday.run(),
         "date_range_start": None,
     },
 }


### PR DESCRIPTION
## Descrição
Ajusta o parâmetro padrão de date_range_end para ser obtido através da função `get_yesterday`. Essa alteração está relacionada ao PR https://github.com/prefeitura-rio/queries-datario/pull/53