### PR TITLE
[hotfix] get_previous_date

### DIFF
--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -3,8 +3,6 @@
 """
 Tasks for rj_smtr
 """
-import prefect.utilities
-
 from datetime import datetime, timedelta
 import json
 import os
@@ -21,6 +19,8 @@ import pendulum
 from prefect import task
 from pytz import timezone
 import requests
+
+import prefect.utilities
 
 from pipelines.rj_smtr.constants import constants
 from pipelines.rj_smtr.utils import (

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -3,6 +3,7 @@
 """
 Tasks for rj_smtr
 """
+import prefect.utilities
 
 from datetime import datetime, timedelta
 import json
@@ -763,7 +764,7 @@ def get_join_dict(dict_list: list, new_dict: dict) -> List:
     return dict_list
 
 
-@task
+@prefect.task(checkpoint=False)
 def get_previous_date(days):
     """
     Returns the date of {days} days ago in YYYY-MM-DD.


### PR DESCRIPTION
Adicionado parâmetro de `@prefect.task(checkpoint=False)` para não utilizar resultados em cache. Para maiores informações: https://discourse.prefect.io/t/why-results-need-to-be-configured-in-order-to-use-retries/867