### PR TITLE
hotfix: Realocação SPPO

### DIFF
--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -130,7 +130,7 @@ with Flow(
 realocacao_sppo.storage = GCS(emd_constants.GCS_FLOWS_BUCKET.value)
 realocacao_sppo.run_config = KubernetesRun(
     image=emd_constants.DOCKER_IMAGE.value,
-    labels=[emd_constants.RJ_SMTR_AGENT_LABEL.value],
+    labels=[emd_constants.RJ_SMTR_DEV_AGENT_LABEL.value],
 )
 realocacao_sppo.schedule = every_10_minutes
 

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -59,7 +59,7 @@ from pipelines.utils.execute_dbt_model.tasks import run_dbt_model
 # Flows #
 
 with Flow(
-    "[Teste] SMTR: GPS SPPO - Realocação (captura)",
+    "SMTR: GPS SPPO - Realocação (captura)",
     code_owners=["caio", "fernanda", "boris", "rodrigo"],
 ) as realocacao_sppo:
 
@@ -130,7 +130,7 @@ with Flow(
 realocacao_sppo.storage = GCS(emd_constants.GCS_FLOWS_BUCKET.value)
 realocacao_sppo.run_config = KubernetesRun(
     image=emd_constants.DOCKER_IMAGE.value,
-    labels=[emd_constants.RJ_SMTR_DEV_AGENT_LABEL.value],
+    labels=[emd_constants.RJ_SMTR_AGENT_LABEL.value],
 )
 realocacao_sppo.schedule = every_10_minutes
 

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -59,7 +59,7 @@ from pipelines.utils.execute_dbt_model.tasks import run_dbt_model
 # Flows #
 
 with Flow(
-    "SMTR: GPS SPPO - Realocação (captura)",
+    "[Teste] SMTR: GPS SPPO - Realocação (captura)",
     code_owners=["caio", "fernanda", "boris", "rodrigo"],
 ) as realocacao_sppo:
 

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
@@ -95,15 +95,13 @@ def pre_treatment_br_rj_riodejaneiro_onibus_realocacao(
         temp_time_col_sec = pd.to_datetime(
             df_realocacao[col], format="%Y-%m-%dT%H:%M:%S", errors="coerce"
         ).dt.tz_localize(tz=constants.TIMEZONE.value)
-        temp_time_col_msec = (
-            pd.to_datetime(
-                df_realocacao[col], format="%Y-%m-%dT%H:%M:%S.%f", errors="coerce"
-            )
-            .dt.tz_localize(tz=constants.TIMEZONE.value)
-            .strftime("%Y-%m-%d %H:%M:%S%z")
-        )
+        temp_time_col_msec = pd.to_datetime(
+            df_realocacao[col], format="%Y-%m-%dT%H:%M:%S.%f", errors="coerce"
+        ).dt.tz_localize(tz=constants.TIMEZONE.value)
 
-        df_realocacao[col] = temp_time_col_sec.fillna(temp_time_col_msec)
+        df_realocacao[col] = temp_time_col_sec.fillna(temp_time_col_msec).dt.strftime(
+            "%Y-%m-%d %H:%M:%S%z"
+        )
 
         if df_realocacao[col].isna().sum() > 0:
             error = ValueError("After treating, there is null values!")

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
@@ -111,7 +111,7 @@ def pre_treatment_br_rj_riodejaneiro_onibus_realocacao(
 
     # Ajusta tempo máximo da realocação
     df_realocacao.loc[
-        df_realocacao.dataSaida == "1971-01-01 00:00:00", "dataSaida"
+        df_realocacao.dataSaida == "1971-01-01 00:00:00-0300", "dataSaida"
     ] = ""
 
     # Renomeia colunas

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
@@ -91,10 +91,10 @@ def pre_treatment_br_rj_riodejaneiro_onibus_realocacao(
         log(f"Converting column {col}")
         log(f"Data received to treat: \n{df_realocacao[col]}")
         temp_time_col_sec = pd.to_datetime(
-            df_realocacao[col], format="%Y-%m-%dT%H:%M:%S", erros="coerce"
+            df_realocacao[col], format="%Y-%m-%dT%H:%M:%S", errors="coerce"
         ).dt.tz_localize(tz=constants.TIMEZONE.value)
         temp_time_col_msec = pd.to_datetime(
-            df_realocacao[col], format="%Y-%m-%dT%H:%M:%S.%f", erros="coerce"
+            df_realocacao[col], format="%Y-%m-%dT%H:%M:%S.%f", errors="coerce"
         ).dt.tz_localize(tz=constants.TIMEZONE.value)
 
         df_realocacao[col] = temp_time_col_sec.fillna(temp_time_col_msec)

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
@@ -95,9 +95,13 @@ def pre_treatment_br_rj_riodejaneiro_onibus_realocacao(
         temp_time_col_sec = pd.to_datetime(
             df_realocacao[col], format="%Y-%m-%dT%H:%M:%S", errors="coerce"
         ).dt.tz_localize(tz=constants.TIMEZONE.value)
-        temp_time_col_msec = pd.to_datetime(
-            df_realocacao[col], format="%Y-%m-%dT%H:%M:%S.%f", errors="coerce"
-        ).dt.tz_localize(tz=constants.TIMEZONE.value)
+        temp_time_col_msec = (
+            pd.to_datetime(
+                df_realocacao[col], format="%Y-%m-%dT%H:%M:%S.%f", errors="coerce"
+            )
+            .dt.tz_localize(tz=constants.TIMEZONE.value)
+            .strftime("%Y-%m-%d %H:%M:%S%z")
+        )
 
         df_realocacao[col] = temp_time_col_sec.fillna(temp_time_col_msec)
 

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
@@ -122,7 +122,7 @@ def pre_treatment_br_rj_riodejaneiro_onibus_realocacao(
 
     df_realocacao = df_realocacao.rename(columns=cols)
 
-    return {"data": df_realocacao.drop_duplicates(), "error": None}
+    return {"data": df_realocacao.drop_duplicates(), "error": error}
 
 
 @task

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
@@ -88,9 +88,9 @@ def pre_treatment_br_rj_riodejaneiro_onibus_realocacao(
     ]
     for col in dt_cols:
         log(f"Converting column {col}")
-        df_realocacao[col] = pd.to_datetime(df_realocacao[col]).dt.tz_localize(
-            tz=constants.TIMEZONE.value
-        )
+        df_realocacao[col] = pd.to_datetime(
+            df_realocacao[col], format="ISO8601"
+        ).dt.tz_localize(tz=constants.TIMEZONE.value)
 
     # Ajusta tempo máximo da realocação
     df_realocacao.loc[

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=W0702, W0718
 """
 Tasks for br_rj_riodejaneiro_onibus_gps
 """
@@ -88,9 +89,15 @@ def pre_treatment_br_rj_riodejaneiro_onibus_realocacao(
     ]
     for col in dt_cols:
         log(f"Converting column {col}")
-        df_realocacao[col] = pd.to_datetime(
-            df_realocacao[col], format="ISO8601"
-        ).dt.tz_localize(tz=constants.TIMEZONE.value)
+        try:
+            df_realocacao[col] = pd.to_datetime(
+                df_realocacao[col], format="%Y-%m-%dT%H:%M:%S"
+            ).dt.tz_localize(tz=constants.TIMEZONE.value)
+        except Exception as e:
+            log(f"[CATCHED] {e} - Dealing with miliseconds")
+            df_realocacao[col] = pd.to_datetime(
+                df_realocacao[col], format="%Y-%m-%dT%H:%M:%S.%f"
+            ).dt.tz_localize(tz=constants.TIMEZONE.value)
 
     # Ajusta tempo máximo da realocação
     df_realocacao.loc[

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/tasks.py
@@ -73,6 +73,8 @@ def pre_treatment_br_rj_riodejaneiro_onibus_realocacao(
         log("Data is empty, skipping treatment...")
         return {"data": pd.DataFrame(), "error": status["error"]}
 
+    error = None
+
     log(f"Data received to treat: \n{status['data'][:5]}")
     df_realocacao = pd.DataFrame(status["data"])  # pylint: disable=c0103
     # df_realocacao["timestamp_captura"] = timestamp

--- a/pipelines/rj_smtr/utils.py
+++ b/pipelines/rj_smtr/utils.py
@@ -55,7 +55,7 @@ def create_or_append_table(
             path=dirpath,
             if_table_exists="pass",
             if_storage_data_exists="replace",
-            if_table_config_exists="replace",
+            # if_table_config_exists="replace",
         )
         log("Table created in STAGING")
     else:

--- a/pipelines/rj_smtr/utils.py
+++ b/pipelines/rj_smtr/utils.py
@@ -55,7 +55,6 @@ def create_or_append_table(
             path=dirpath,
             if_table_exists="pass",
             if_storage_data_exists="replace",
-            # if_table_config_exists="replace",
         )
         log("Table created in STAGING")
     else:


### PR DESCRIPTION
- Corrige a task `pre_treatment_br_rj_riodejaneiro_onibus_realocacao`, considerando dois possíveis formatos de `datetime` e os padroniza;
- Remove parâmetro em desuso na função `create_or_append_table`, com a atualização do pacote da `basedosdados`.