### PR TITLE
[SMTR] [FIX] Ajusta flows de materialização e tasks de date_range

### DIFF
--- a/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
@@ -84,7 +84,7 @@ with Flow(
         table_id=table_id,
         raw_dataset_id=raw_dataset_id,
         raw_table_id=raw_table_id,
-        table_date_column_name="timestamp_gps",
+        table_run_datetime_column_name="timestamp_gps",
         mode=MODE,
         delay_hours=constants.GPS_BRT_MATERIALIZE_DELAY_HOURS.value,
     )

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_brt_gps/flows.py
@@ -84,7 +84,7 @@ with Flow(
         table_id=table_id,
         raw_dataset_id=raw_dataset_id,
         raw_table_id=raw_table_id,
-        table_date_column_name="data",
+        table_date_column_name="timestamp_gps",
         mode=MODE,
         delay_hours=constants.GPS_BRT_MATERIALIZE_DELAY_HOURS.value,
     )

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -168,7 +168,7 @@ with Flow(
         table_id=table_id,
         raw_dataset_id=raw_dataset_id,
         raw_table_id=raw_table_id,
-        table_date_column_name="data",
+        table_date_column_name="timestamp_gps",
         mode=MODE,
         delay_hours=constants.GPS_SPPO_MATERIALIZE_DELAY_HOURS.value,
     )

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_onibus_gps/flows.py
@@ -168,7 +168,7 @@ with Flow(
         table_id=table_id,
         raw_dataset_id=raw_dataset_id,
         raw_table_id=raw_table_id,
-        table_date_column_name="timestamp_gps",
+        table_run_datetime_column_name="timestamp_gps",
         mode=MODE,
         delay_hours=constants.GPS_SPPO_MATERIALIZE_DELAY_HOURS.value,
     )

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -638,6 +638,9 @@ def get_materialization_date_range(  # pylint: disable=R0913
     )
     # if there's no timestamp set on redis, get max timestamp on source table
     if last_run is None:
+        print(
+            "Failed to fetch key from Redis...\n Querying tables for last suceeded run"
+        )
         if Table(dataset_id=dataset_id, table_id=table_id).table_exists("prod"):
             last_run = get_table_min_max_value(
                 query_project_id=bq_project(),
@@ -645,6 +648,13 @@ def get_materialization_date_range(  # pylint: disable=R0913
                 table_id=table_id,
                 field_name=table_date_column_name,
                 kind="max",
+            )
+            print(
+                f"""
+            Queried last run from {dataset_id}.{table_id}
+            Got:
+            {last_run} as type {type(last_run)}
+            """
             )
         else:
             last_run = get_table_min_max_value(
@@ -654,6 +664,13 @@ def get_materialization_date_range(  # pylint: disable=R0913
                 field_name=table_date_column_name,
                 kind="max",
             )
+        print(
+            f"""
+            Queried last run from {raw_dataset_id}.{raw_table_id}
+            Got:
+            {last_run} as type {type(last_run)}
+            """
+        )
     else:
         last_run = datetime.strptime(last_run, timestr)
 

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -300,7 +300,9 @@ def query_logs(
             second=0, microsecond=0
         )
     elif isinstance(datetime_filter, str):
-        datetime_filter = datetime.fromisoformat(datetime_filter)
+        datetime_filter = datetime.fromisoformat(datetime_filter).replace(
+            second=0, microsecond=0
+        )
 
     query = f"""
     with t as (
@@ -614,7 +616,7 @@ def get_materialization_date_range(  # pylint: disable=R0913
     table_id: str,
     raw_dataset_id: str,
     raw_table_id: str,
-    table_date_column_name: str = None,
+    table_run_datetime_column_name: str = None,
     mode: str = "prod",
     delay_hours: int = 0,
 ):
@@ -649,7 +651,7 @@ def get_materialization_date_range(  # pylint: disable=R0913
                 query_project_id=bq_project(),
                 dataset_id=dataset_id,
                 table_id=table_id,
-                field_name=table_date_column_name,
+                field_name=table_run_datetime_column_name,
                 kind="max",
             )
             log(
@@ -664,7 +666,7 @@ def get_materialization_date_range(  # pylint: disable=R0913
                 query_project_id=bq_project(),
                 dataset_id=raw_dataset_id,
                 table_id=raw_table_id,
-                field_name=table_date_column_name,
+                field_name=table_run_datetime_column_name,
                 kind="max",
             )
         log(

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -276,7 +276,10 @@ def save_treated_local(file_path: str, status: dict, mode: str = "staging") -> s
 ###############
 @task(nout=3)
 def query_logs(
-    dataset_id: str, table_id: str, datetime_filter=None, max_recaptures: int = 60
+    dataset_id: str,
+    table_id: str,
+    datetime_filter=None,
+    max_recaptures: int = 60,
 ):
     """
     Queries capture logs to check for errors
@@ -296,6 +299,8 @@ def query_logs(
         datetime_filter = pendulum.now(constants.TIMEZONE.value).replace(
             second=0, microsecond=0
         )
+    elif isinstance(datetime_filter, str):
+        datetime_filter = datetime.fromisoformat(datetime_filter)
 
     query = f"""
     with t as (
@@ -716,6 +721,8 @@ def set_last_run_timestamp(
     if mode == "dev":
         key = f"{mode}.{key}"
     content = redis_client.get(key)
+    if not content:
+        content = {}
     content["last_run_timestamp"] = timestamp
     redis_client.set(key, content)
     return True

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -643,9 +643,7 @@ def get_materialization_date_range(  # pylint: disable=R0913
     )
     # if there's no timestamp set on redis, get max timestamp on source table
     if last_run is None:
-        print(
-            "Failed to fetch key from Redis...\n Querying tables for last suceeded run"
-        )
+        log("Failed to fetch key from Redis...\n Querying tables for last suceeded run")
         if Table(dataset_id=dataset_id, table_id=table_id).table_exists("prod"):
             last_run = get_table_min_max_value(
                 query_project_id=bq_project(),
@@ -654,7 +652,7 @@ def get_materialization_date_range(  # pylint: disable=R0913
                 field_name=table_date_column_name,
                 kind="max",
             )
-            print(
+            log(
                 f"""
             Queried last run from {dataset_id}.{table_id}
             Got:
@@ -669,7 +667,7 @@ def get_materialization_date_range(  # pylint: disable=R0913
                 field_name=table_date_column_name,
                 kind="max",
             )
-        print(
+        log(
             f"""
             Queried last run from {raw_dataset_id}.{raw_table_id}
             Got:

--- a/pipelines/rj_smtr/utils.py
+++ b/pipelines/rj_smtr/utils.py
@@ -114,13 +114,13 @@ def get_table_min_max_value(  # pylint: disable=R0913
         field_name (str): column name to query
         kind (str): which value to get. Accepts min and max
     """
-    print(f"Getting {kind} value for {table_id}")
+    log(f"Getting {kind} value for {table_id}")
     query = f"""
         SELECT
             {kind}({field_name})
         FROM {query_project_id}.{dataset_id}.{table_id}
     """
-    print(f"Will run query:\n{query}")
+    log(f"Will run query:\n{query}")
     result = bd.read_sql(query=query, billing_project_id=bq_project())
 
     return result.iloc[0][0]

--- a/pipelines/rj_smtr/utils.py
+++ b/pipelines/rj_smtr/utils.py
@@ -114,11 +114,13 @@ def get_table_min_max_value(  # pylint: disable=R0913
         field_name (str): column name to query
         kind (str): which value to get. Accepts min and max
     """
+    print(f"Getting {kind} value for {table_id}")
     query = f"""
         SELECT
             {kind}({field_name})
         FROM {query_project_id}.{dataset_id}.{table_id}
     """
+    print(f"Will run query:\n{query}")
     result = bd.read_sql(query=query, billing_project_id=bq_project())
 
     return result.iloc[0][0]


### PR DESCRIPTION
Após uma instabilidade no cluster, durante a configuração da VPN, as chaves que usamos no Redis para controlar as `date_ranges` de materalização foram resetadas/esvaziadas. Até então, operamos assumindo que o código era resiliente o suficiente para setar novamente as chaves nesse caso, o que não foi verificado.
As mudanças presentes aqui, corrigem as falhas desse passo de resiliência.

Changelog:
-  Muda o valor do argumento `table_date_column_name`, bem como o nome do argumento para `table_run_datetime_column_name`, da task `get_materialization_date_range` usada nos flows de materialização: A task não estava conseguindo setar os valores corretamente no redis por fazer a query num campo de data na tabela. Mudando para `timestamp_gps`, temos o tipo certo de variável e maior certeza sobre qual foi o último período no qual a materialização funcionou.
- Adiciona um condicional em `set_last_run_timestamp`: útil para casos onde a chave não existe e precisa ser setada novamente.
- Adiciona mais logs nas tasks para melhor identificação de erros futuros