### PR TITLE
Unifica tasks de partição de data e hora

### DIFF
--- a/pipelines/rj_smtr/constants.py
+++ b/pipelines/rj_smtr/constants.py
@@ -180,7 +180,7 @@ class constants(Enum):  # pylint: disable=c0103
                 ORDER BY
                     data_processamento
             """,
-            "primary_key": ["id"]  # id column to nest data on
+            "primary_key": ["id"],  # id column to nest data on
         },
     ]
     BILHETAGEM_TABLES_PARAMS = [

--- a/pipelines/rj_smtr/constants.py
+++ b/pipelines/rj_smtr/constants.py
@@ -180,8 +180,7 @@ class constants(Enum):  # pylint: disable=c0103
                 ORDER BY
                     data_processamento
             """,
-            "primary_key": ["id"],  # id column to nest data on
-            "flag_date_partition": False,
+            "primary_key": ["id"]  # id column to nest data on
         },
     ]
     BILHETAGEM_TABLES_PARAMS = [
@@ -199,7 +198,7 @@ class constants(Enum):  # pylint: disable=c0103
                     DT_INCLUSAO
             """,
             "primary_key": ["CD_LINHA"],  # id column to nest data on
-            "flag_date_partition": True,
+            "partition_date_only": True,
         },
         {
             "table_id": "grupo",
@@ -215,7 +214,7 @@ class constants(Enum):  # pylint: disable=c0103
                     DT_INCLUSAO
             """,
             "primary_key": ["CD_GRUPO"],
-            "flag_date_partition": True,
+            "partition_date_only": True,
         },
         {
             "table_id": "grupo_linha",
@@ -231,7 +230,7 @@ class constants(Enum):  # pylint: disable=c0103
                     DT_INCLUSAO
             """,
             "primary_key": ["CD_GRUPO", "CD_LINHA"],  # id column to nest data on
-            "flag_date_partition": True,
+            "partition_date_only": True,
         },
         {
             "table_id": "matriz_integracao",
@@ -250,7 +249,7 @@ class constants(Enum):  # pylint: disable=c0103
                 "cd_versao_matriz",
                 "cd_integracao",
             ],  # id column to nest data on
-            "flag_date_partition": True,
+            "partition_date_only": True,
         },
     ]
     BILHETAGEM_SECRET_PATH = "smtr_jae_access_data"

--- a/pipelines/rj_smtr/flows.py
+++ b/pipelines/rj_smtr/flows.py
@@ -5,8 +5,7 @@ Flows for rj_smtr
 
 from prefect.run_configs import KubernetesRun
 from prefect.storage import GCS
-from prefect import case, Parameter
-from prefect.tasks.control_flow import merge
+from prefect import Parameter
 
 # EMD Imports #
 
@@ -19,7 +18,6 @@ from pipelines.utils.tasks import (
 # SMTR Imports #
 
 from pipelines.rj_smtr.tasks import (
-    create_date_partition,
     create_date_hour_partition,
     create_local_partition_path,
     get_current_timestamp,
@@ -66,13 +64,7 @@ with Flow(
         dataset_id=dataset_id,
     )
 
-    with case(table_params["flag_date_partition"], True):
-        date_partitions = create_date_partition(timestamp)
-
-    with case(table_params["flag_date_partition"], False):
-        date_hour_partitions = create_date_hour_partition(timestamp)
-
-    partitions = merge(date_partitions, date_hour_partitions)
+    partitions = create_date_hour_partition(timestamp, partition_date_only=table_params["partition_date_only"])
 
     filename = parse_timestamp_to_string(timestamp)
 

--- a/pipelines/rj_smtr/flows.py
+++ b/pipelines/rj_smtr/flows.py
@@ -64,7 +64,9 @@ with Flow(
         dataset_id=dataset_id,
     )
 
-    partitions = create_date_hour_partition(timestamp, partition_date_only=table_params["partition_date_only"])
+    partitions = create_date_hour_partition(
+        timestamp, partition_date_only=table_params["partition_date_only"]
+    )
 
     filename = parse_timestamp_to_string(timestamp)
 

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -158,7 +158,9 @@ def get_current_timestamp(timestamp=None, truncate_minute: bool = True) -> datet
 
 
 @task
-def create_date_hour_partition(timestamp: datetime, partition_date_only: bool = False) -> str:
+def create_date_hour_partition(
+    timestamp: datetime, partition_date_only: bool = False
+) -> str:
     """
     Get date hour Hive partition structure from timestamp.
     """

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -182,34 +182,6 @@ def parse_timestamp_to_string(timestamp: datetime, pattern="%Y-%m-%d-%H-%M-%S") 
 
 
 @task
-def create_current_date_hour_partition(capture_time=None):
-    """Create partitioned directory structure to save data locally based
-    on capture time.
-
-    Args:
-        capture_time(pendulum.datetime.DateTime, optional):
-            if recapturing data, will create partitions based
-            on the failed timestamps being recaptured
-
-    Returns:
-        dict: "filename" contains the name which to upload the csv, "partitions" contains
-        the partitioned directory path
-    """
-    if capture_time is None:
-        capture_time = datetime.now(tz=constants.TIMEZONE.value).replace(
-            minute=0, second=0, microsecond=0
-        )
-    date = capture_time.strftime("%Y-%m-%d")
-    hour = capture_time.strftime("%H")
-
-    return {
-        "filename": capture_time.strftime("%Y-%m-%d-%H-%M-%S"),
-        "partitions": f"data={date}/hora={hour}",
-        "timestamp": capture_time,
-    }
-
-
-@task
 def create_local_partition_path(
     dataset_id: str, table_id: str, filename: str, partitions: str = None
 ) -> str:

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -165,8 +165,8 @@ def create_date_hour_partition(
     Get date hour Hive partition structure from timestamp.
     """
     partition = f"data={timestamp.strftime('%Y-%m-%d')}"
-    if partition_date_only:
-        parition += f"/hora={timestamp.strftime('%H')}"
+    if not partition_date_only:
+        partition += f"/hora={timestamp.strftime('%H')}"
     return partition
 
 

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -158,19 +158,14 @@ def get_current_timestamp(timestamp=None, truncate_minute: bool = True) -> datet
 
 
 @task
-def create_date_hour_partition(timestamp: datetime) -> str:
+def create_date_hour_partition(timestamp: datetime, partition_date_only: bool = False) -> str:
     """
     Get date hour Hive partition structure from timestamp.
     """
-    return f"data={timestamp.strftime('%Y-%m-%d')}/hora={timestamp.strftime('%H')}"
-
-
-@task
-def create_date_partition(timestamp: datetime) -> str:
-    """
-    Get date hour Hive partition structure from timestamp.
-    """
-    return f"data={timestamp.date()}"
+    partition = f"data={timestamp.strftime('%Y-%m-%d')}"
+    if partition_date_only:
+        parition += f"/hora={timestamp.strftime('%H')}"
+    return partition
 
 
 @task

--- a/pipelines/rj_smtr/veiculo/flows.py
+++ b/pipelines/rj_smtr/veiculo/flows.py
@@ -30,7 +30,7 @@ from pipelines.rj_smtr.schedules import (
     every_day_hour_seven,
 )
 from pipelines.rj_smtr.tasks import (
-    create_date_partition,
+    create_date_hour_partition,
     create_local_partition_path,
     get_current_timestamp,
     get_raw,
@@ -71,7 +71,7 @@ with Flow(
     )
 
     # SETUP #
-    partitions = create_date_partition(timestamp)
+    partitions = create_date_hour_partition(timestamp, partition_date_only=True)
 
     filename = parse_timestamp_to_string(timestamp)
 
@@ -140,7 +140,7 @@ with Flow(
     )
 
     # SETUP #
-    partitions = create_date_partition(timestamp)
+    partitions = create_date_hour_partition(timestamp, partition_date_only=True)
 
     filename = parse_timestamp_to_string(timestamp)
 


### PR DESCRIPTION
Changelog:

- Unificação da task `create_date_hour_partition` e `create_date_partition`, mantendo a 1a com o parâmetro `partition_date_only` (bool)
- Refatoração das pipelines afetadas (`veiculo` e `bilhetagem`)
- Remoção de uma task não utilizada em nenhuma pipeline `create_current_date_hour_partition`

@pixuimpou @eng-rodrigocunha necessário testar antes de aprovar