### PR TITLE
Adiciona novos `code_owners` da SMTR 🫂 

### DIFF
--- a/code_owners.yaml
+++ b/code_owners.yaml
@@ -20,6 +20,8 @@ pipelines:
         - fernandascovino
         - eng-rodrigocunha
         - borismarinho
+        - pixuimpou
+        - lingsv
     rj_escritorio:
       owners:
         - gabriel-milan

--- a/pipelines/constants.py
+++ b/pipelines/constants.py
@@ -145,5 +145,5 @@ class constants(Enum):  # pylint: disable=c0103
         "carolinagomes": {
             "user_id": "620000269392019469",
             "type": "user_nickname",
-        }
+        },
     }

--- a/pipelines/constants.py
+++ b/pipelines/constants.py
@@ -138,4 +138,12 @@ class constants(Enum):  # pylint: disable=c0103
             "user_id": "369657115012366336",
             "type": "user_nickname",
         },
+        "rafaelpinheiro": {
+            "user_id": "1131538976101109772",
+            "type": "user_nickname",
+        },
+        "carolinagomes": {
+            "user_id": "620000269392019469",
+            "type": "user_nickname",
+        }
     }


### PR DESCRIPTION
TODO:
- [x] Adicionar Carol e Rafa
- [ ] Definir owners por pasta (prox PR)
- [ ] Trocar nomes da galera da smtr para `nomesobrenome` (prox PR)