### PR TITLE
Corrige parâmetro de `partition_date_only` no flow de bilhetagem

### DIFF
--- a/pipelines/rj_smtr/constants.py
+++ b/pipelines/rj_smtr/constants.py
@@ -181,6 +181,7 @@ class constants(Enum):  # pylint: disable=c0103
                     data_processamento
             """,
             "primary_key": ["id"],  # id column to nest data on
+            "partition_date_only": False,
         },
     ]
     BILHETAGEM_TABLES_PARAMS = [


### PR DESCRIPTION
# ChangeLog
- adiciona a key partition_date_only na constante de table params da transação