### PR TITLE
chore: change overwrite mode

### DIFF
--- a/pipelines/rj_smfp/dump_db_sigma/flows.py
+++ b/pipelines/rj_smfp/dump_db_sigma/flows.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Database dumping flows for SMFP SIGMA system
+Database dumping flows for SMFP SIGMA system.
 """
 
 from copy import deepcopy

--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -233,9 +233,7 @@ def create_table_and_upload_to_gcs(
             # delete only staging table and let DBT overwrite the prod table
             tb.delete(mode="staging")
             log(
-                "MODE OVERWRITE: Sucessfully DELETED TABLE:\n"
-                f"{table_staging}\n"
-                f"{tb.table_full_name['prod']}"
+                "MODE OVERWRITE: Sucessfully DELETED TABLE:\n" f"{table_staging}\n"
             )  # pylint: disable=C0301
 
         # the header is needed to create a table when dosen't exist

--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -230,7 +230,8 @@ def create_table_and_upload_to_gcs(
                 f"{storage_path}\n"
                 f"{storage_path_link}"
             )  # pylint: disable=C0301
-            tb.delete(mode="all")
+            # delete only staging table and let DBT overwrite the prod table
+            tb.delete(mode="staging")
             log(
                 "MODE OVERWRITE: Sucessfully DELETED TABLE:\n"
                 f"{table_staging}\n"


### PR DESCRIPTION
Agora no mode `overwrite` a unica tabela deletada é a de `staging` e a tabela de `prod` so vai ser sobrescrita pelo DBT. 
Em caso de falha do DBT a versão antiga continua existindo, evitando problemas de sumiço de tabelas.