### PR TITLE
[gtfs_captura_tratamento] Adiciona schedule para runs 

### DIFF
--- a/pipelines/rj_smtr/br_rj_riodejaneiro_gtfs/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_gtfs/flows.py
@@ -26,9 +26,7 @@ from pipelines.utils.tasks import (
 
 # SMTR Imports #
 from pipelines.rj_smtr.constants import constants
-from pipelines.rj_smtr.tasks import (
-    get_current_timestamp,
-)
+from pipelines.rj_smtr.tasks import get_current_timestamp, get_scheduled_start_times
 
 from pipelines.rj_smtr.flows import default_capture_flow, default_materialization_flow
 
@@ -88,6 +86,9 @@ with Flow(
             project_name=unmapped(emd_constants.PREFECT_DEFAULT_PROJECT.value),
             parameters=gtfs_capture_parameters,
             labels=unmapped(LABELS),
+            scheduled_start_time=get_scheduled_start_times(
+                timestamp=timestamp, parameters=gtfs_capture_parameters
+            ),
         )
 
         wait_captura_true = wait_for_flow_run.map(

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_gtfs/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_gtfs/flows.py
@@ -69,7 +69,7 @@ with Flow(
     timestamp = get_current_timestamp()
 
     rename_flow_run = rename_current_flow_run_now_time(
-        prefix=gtfs_captura_tratamento.name + " ",
+        prefix=gtfs_captura_tratamento.name + " " + data_versao_gtfs + " ",
         now_time=timestamp,
     )
 

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_gtfs/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_gtfs/flows.py
@@ -3,6 +3,7 @@
 Flows for gtfs
 """
 from copy import deepcopy
+from datetime import timedelta
 
 # Imports #
 
@@ -87,7 +88,9 @@ with Flow(
             parameters=gtfs_capture_parameters,
             labels=unmapped(LABELS),
             scheduled_start_time=get_scheduled_start_times(
-                timestamp=timestamp, parameters=gtfs_capture_parameters
+                timestamp=timestamp,
+                parameters=gtfs_capture_parameters,
+                intervals={"agency": timedelta(minutes=11)},
             ),
         )
 

--- a/pipelines/rj_smtr/constants.py
+++ b/pipelines/rj_smtr/constants.py
@@ -466,6 +466,10 @@ class constants(Enum):  # pylint: disable=c0103
 
     GTFS_TABLE_CAPTURE_PARAMS = [
         {
+            "table_id": "shapes",
+            "primary_key": ["shape_id", "shape_pt_sequence"],
+        },
+        {
             "table_id": "agency",
             "primary_key": ["agency_id"],
         },
@@ -490,16 +494,8 @@ class constants(Enum):  # pylint: disable=c0103
             "primary_key": ["route_id"],
         },
         {
-            "table_id": "shapes",
-            "primary_key": ["shape_id", "shape_pt_sequence"],
-        },
-        {
             "table_id": "stops",
             "primary_key": ["stop_id"],
-        },
-        {
-            "table_id": "stop_times",
-            "primary_key": ["trip_id", "stop_sequence"],
         },
         {
             "table_id": "trips",
@@ -517,6 +513,10 @@ class constants(Enum):  # pylint: disable=c0103
             "table_id": "ordem_servico",
             "primary_key": ["servico"],
             "extract_params": {"filename": "ordem_servico"},
+        },
+        {
+            "table_id": "stop_times",
+            "primary_key": ["trip_id", "stop_sequence"],
         },
     ]
 

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -1379,3 +1379,23 @@ def check_mapped_query_logs_output(query_logs_output: list[tuple]) -> bool:
 
     recapture_list = [i[0] for i in query_logs_output]
     return any(recapture_list)
+
+
+@task
+def get_scheduled_start_times(
+    timestamp: datetime, parameters: list, interval=timedelta(minutes=5)
+):
+    """
+    Task to get start times to schedule flows
+
+    Args:
+        timestamp (datetime): the flow run timestamp
+        parameters (list): the parameters for the flow
+        interval (timedelta, optional): the timedelta between each flow run.
+            Defaults to timedelta(minutes=5).
+
+    Returns:
+        list: list of scheduled start times
+    """
+
+    return [timestamp + i * interval for i in range(len(parameters))]

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -1383,7 +1383,7 @@ def check_mapped_query_logs_output(query_logs_output: list[tuple]) -> bool:
 
 @task
 def get_scheduled_start_times(
-    timestamp: datetime, parameters: list, interval=timedelta(minutes=5)
+    timestamp: datetime, parameters: list, interval=timedelta(minutes=2)
 ):
     """
     Task to get start times to schedule flows

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -1398,4 +1398,4 @@ def get_scheduled_start_times(
         list: list of scheduled start times
     """
 
-    return [timestamp + i * interval for i in range(len(parameters))]
+    return [None] + [timestamp + i * interval for i in range(1, len(parameters))]

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -1382,28 +1382,29 @@ def check_mapped_query_logs_output(query_logs_output: list[tuple]) -> bool:
 
 
 @task
-def get_scheduled_start_times(timestamp: datetime, parameters: list, intervals=None):
+def get_scheduled_start_times(
+    timestamp: datetime, parameters: list, intervals: Union[None, dict] = None
+):
     """
     Task to get start times to schedule flows
 
     Args:
         timestamp (datetime): initial flow run timestamp
         parameters (list): parameters for the flow
-        intervals (dict, optional): intervals between each parameter.
+        intervals (Union[None, dict], optional): intervals between each flow run. Defaults to None.
             Optionally, you can pass specific intervals for some table_ids.
             Suggests to pass intervals based on previous table observed execution times.
-            Defaults to dict(default=timedelta(minutes=2), agency=timedelta(minutes=7)).
-            A dict at least with default key is required.
+            Defaults to dict(default=timedelta(minutes=2)).
 
     Returns:
         list[datetime]: list of scheduled start times
     """
 
     if intervals is None:
-        intervals = {"default": timedelta(minutes=2), "agency": timedelta(minutes=11)}
-    else:
-        if "default" not in intervals.keys():
-            raise ValueError("A default interval must be passed")
+        intervals = dict()
+
+    if "default" not in intervals.keys():
+        intervals["default"] = timedelta(minutes=2)
 
     timestamps = [None]
     last_schedule = timestamp

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -1400,7 +1400,10 @@ def get_scheduled_start_times(timestamp: datetime, parameters: list, intervals=N
     """
 
     if intervals is None:
-        intervals = {"default": timedelta(minutes=2), "agency": timedelta(minutes=7)}
+        intervals = {"default": timedelta(minutes=2), "agency": timedelta(minutes=11)}
+    else:
+        if "default" not in intervals.keys():
+            raise ValueError("A default interval must be passed")
 
     timestamps = [None]
     last_schedule = timestamp

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -1389,9 +1389,9 @@ def get_scheduled_start_times(
     Task to get start times to schedule flows
 
     Args:
-        timestamp (datetime): the flow run timestamp
-        parameters (list): the parameters for the flow
-        interval (timedelta, optional): the timedelta between each flow run.
+        timestamp (datetime): initial flow run timestamp
+        parameters (list): parameters for the flow
+        interval (timedelta, optional): timedelta between each flow run.
             Defaults to timedelta(minutes=5).
 
     Returns:


### PR DESCRIPTION
Ao utilizar a task `create_flow_run.map`, por padrão, todas as runs são criadas simultaneamente. Isso gera um uso excessivo de recursos no pod. Para tentar otimizar o uso de recursos, será fornecido o argumento `scheduled_start_time` com uma lista de timestamps para execução sequenciada de todas as runs, sem necessidade de execução simultânea.