### PR TITLE
Desliga schedule dos flows `sppo_infracao_captura` e `sppo_licenciamento_captura`

### DIFF
--- a/pipelines/rj_smtr/veiculo/CHANGELOG.md
+++ b/pipelines/rj_smtr/veiculo/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - veiculo
+
+## [1.0.0] - 2024-04-25
+
+### Alterado
+
+- Desliga schedule dos flows `sppo_infracao_captura` e `sppo_licenciamento_captura` (https://github.com/prefeitura-rio/pipelines/pull/672)

--- a/pipelines/rj_smtr/veiculo/CHANGELOG.md
+++ b/pipelines/rj_smtr/veiculo/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ### Alterado
 
-- Desliga schedule dos flows `sppo_infracao_captura` e `sppo_licenciamento_captura` (https://github.com/prefeitura-rio/pipelines/pull/672)
+- Desliga schedule dos flows `sppo_infracao_captura` e `sppo_licenciamento_captura` em razão de indisponibilidade e geração de dados imprecisos na fonte (SIURB) (https://github.com/prefeitura-rio/pipelines/pull/672)

--- a/pipelines/rj_smtr/veiculo/flows.py
+++ b/pipelines/rj_smtr/veiculo/flows.py
@@ -140,7 +140,7 @@ sppo_licenciamento_captura.run_config = KubernetesRun(
     image=emd_constants.DOCKER_IMAGE.value,
     labels=[emd_constants.RJ_SMTR_AGENT_LABEL.value],
 )
-sppo_licenciamento_captura.schedule = every_day_hour_seven
+# sppo_licenciamento_captura.schedule = every_day_hour_seven
 
 with Flow(
     f"SMTR: {constants.VEICULO_DATASET_ID.value} {constants.SPPO_INFRACAO_TABLE_ID.value} - Captura",
@@ -218,7 +218,7 @@ sppo_infracao_captura.run_config = KubernetesRun(
     image=emd_constants.DOCKER_IMAGE.value,
     labels=[emd_constants.RJ_SMTR_AGENT_LABEL.value],
 )
-sppo_infracao_captura.schedule = every_day_hour_seven
+# sppo_infracao_captura.schedule = every_day_hour_seven
 
 # flake8: noqa: E501
 with Flow(


### PR DESCRIPTION
# Changelog - veiculo

## [1.0.0] - 2024-04-25

### Alterado

- Desliga schedule dos flows `sppo_infracao_captura` e `sppo_licenciamento_captura` em razão de indisponibilidade e geração de dados imprecisos na fonte (SIURB)