### PR TITLE
Cria parâmetro `project_name` + Inclui argumento `run_config` no flow `gtfs_captura_tratamento`

### DIFF
--- a/pipelines/constants.py
+++ b/pipelines/constants.py
@@ -156,4 +156,8 @@ class constants(Enum):  # pylint: disable=c0103
             "user_id": "1147152438487416873",
             "type": "user_nickname",
         },
+        "dados_smtr": {
+            "user_id": "1056928259700445245",
+            "type": "role",
+        },
     }

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_gtfs/CHANGELOG.md
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_gtfs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - br_rj_riodejaneiro_gtfs
 
+## [1.0.1] - 2024-05-10
+
+### Alterado
+
+- Cria parâmetro `project_name` no flow `gtfs_captura_tratamento` para possibilitar alterar o `project_name` na criação de runs (https://github.com/prefeitura-rio/pipelines/pull/678)
+
 ## [1.0.0] - 2024-04-18
 
 ### Adicionado

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_gtfs/CHANGELOG.md
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_gtfs/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Alterado
 
-- Cria parâmetro `project_name` no flow `gtfs_captura_tratamento` para possibilitar alterar o `project_name` na criação de runs (https://github.com/prefeitura-rio/pipelines/pull/678)
+- Cria parâmetro `project_name` no flow `gtfs_captura_tratamento` para possibilitar alterar o `project_name` ao usar a task `create_flow_run` (https://github.com/prefeitura-rio/pipelines/pull/678)
+- Inclui argumento `run_config` ao usar a task `create_flow_run`, usando sempre como referência a `run_config` do flow principal (https://github.com/prefeitura-rio/pipelines/pull/678)
 
 ## [1.0.0] - 2024-04-18
 

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_gtfs/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_gtfs/flows.py
@@ -66,6 +66,9 @@ with Flow(
     data_versao_gtfs = Parameter("data_versao_gtfs", default=None)
     capture = Parameter("capture", default=True)
     materialize = Parameter("materialize", default=True)
+    project_name = Parameter(
+        "project_name", default=emd_constants.PREFECT_DEFAULT_PROJECT.value
+    )
 
     timestamp = get_current_timestamp()
 
@@ -84,7 +87,7 @@ with Flow(
 
         run_captura = create_flow_run.map(
             flow_name=unmapped(gtfs_captura.name),
-            project_name=unmapped(emd_constants.PREFECT_DEFAULT_PROJECT.value),
+            project_name=unmapped(project_name),
             parameters=gtfs_capture_parameters,
             labels=unmapped(LABELS),
             scheduled_start_time=get_scheduled_start_times(
@@ -123,7 +126,7 @@ with Flow(
 
         run_materializacao = create_flow_run(
             flow_name=gtfs_materializacao.name,
-            project_name=emd_constants.PREFECT_DEFAULT_PROJECT.value,
+            project_name=project_name,
             parameters=gtfs_materializacao_parameters,
             labels=LABELS,
             upstream_tasks=[wait_captura],
@@ -131,7 +134,7 @@ with Flow(
 
         run_materializacao_new_dataset_id = create_flow_run(
             flow_name=gtfs_materializacao.name,
-            project_name=emd_constants.PREFECT_DEFAULT_PROJECT.value,
+            project_name=project_name,
             parameters=gtfs_materializacao_parameters_new,
             labels=LABELS,
             upstream_tasks=[wait_captura],
@@ -154,5 +157,5 @@ with Flow(
 gtfs_captura_tratamento.storage = GCS(emd_constants.GCS_FLOWS_BUCKET.value)
 gtfs_captura_tratamento.run_config = KubernetesRun(
     image=emd_constants.DOCKER_IMAGE.value,
-    labels=[emd_constants.RJ_SMTR_AGENT_LABEL.value],
+    labels=[emd_constants.RJ_SMTR_DEV_AGENT_LABEL.value],
 )

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_gtfs/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_gtfs/flows.py
@@ -140,5 +140,5 @@ with Flow(
 gtfs_captura_tratamento.storage = GCS(emd_constants.GCS_FLOWS_BUCKET.value)
 gtfs_captura_tratamento.run_config = KubernetesRun(
     image=emd_constants.DOCKER_IMAGE.value,
-    labels=[emd_constants.RJ_SMTR_DEV_AGENT_LABEL.value],
+    labels=[emd_constants.RJ_SMTR_AGENT_LABEL.value],
 )

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_gtfs/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_gtfs/flows.py
@@ -95,6 +95,7 @@ with Flow(
                 parameters=gtfs_capture_parameters,
                 intervals={"agency": timedelta(minutes=11)},
             ),
+            run_config=unmapped(gtfs_captura_tratamento.run_config),
         )
 
         wait_captura_true = wait_for_flow_run.map(
@@ -130,6 +131,7 @@ with Flow(
             parameters=gtfs_materializacao_parameters,
             labels=LABELS,
             upstream_tasks=[wait_captura],
+            run_config=gtfs_captura_tratamento.run_config,
         )
 
         run_materializacao_new_dataset_id = create_flow_run(
@@ -138,6 +140,7 @@ with Flow(
             parameters=gtfs_materializacao_parameters_new,
             labels=LABELS,
             upstream_tasks=[wait_captura],
+            run_config=gtfs_captura_tratamento.run_config,
         )
 
         wait_materializacao = wait_for_flow_run(

--- a/pipelines/rj_smtr/constants.py
+++ b/pipelines/rj_smtr/constants.py
@@ -161,7 +161,7 @@ class constants(Enum):  # pylint: disable=c0103
     SUBSIDIO_SPPO_DATASET_ID = "projeto_subsidio_sppo"
     SUBSIDIO_SPPO_SECRET_PATH = "projeto_subsidio_sppo"
     SUBSIDIO_SPPO_TABLE_ID = "viagem_completa"
-    SUBSIDIO_SPPO_CODE_OWNERS = ["rodrigo"]
+    SUBSIDIO_SPPO_CODE_OWNERS = ["dados_smtr"]
 
     # SUBSÍDIO DASHBOARD
     SUBSIDIO_SPPO_DASHBOARD_DATASET_ID = "dashboard_subsidio_sppo"

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -858,18 +858,6 @@ def get_raw_from_sources(
         source_values if len(source_values) == 2 else (source_values[0], None)
     )
 
-    log(
-        f"""
-        Received arguments:
-        source_type: {source_type}
-        local_filepath: {local_filepath}
-        source_path: {source_path}
-        dataset_id: {dataset_id}
-        table_id: {table_id}
-        secret_path: {secret_path}
-        request_params: {request_params}"""
-    )
-
     log(f"Getting raw data from source type: {source_type}")
 
     try:

--- a/pipelines/rj_smtr/tasks.py
+++ b/pipelines/rj_smtr/tasks.py
@@ -856,6 +856,18 @@ def get_raw_from_sources(
         source_values if len(source_values) == 2 else (source_values[0], None)
     )
 
+    log(
+        f"""
+        Received arguments:
+        source_type: {source_type}
+        local_filepath: {local_filepath}
+        source_path: {source_path}
+        dataset_id: {dataset_id}
+        table_id: {table_id}
+        secret_path: {secret_path}
+        request_params: {request_params}"""
+    )
+
     log(f"Getting raw data from source type: {source_type}")
 
     try:


### PR DESCRIPTION
# Changelog - br_rj_riodejaneiro_gtfs

## [1.0.1] - 2024-06-03

### Alterado

- Cria parâmetro `project_name` no flow `gtfs_captura_tratamento` para possibilitar alterar o `project_name` ao usar a task `create_flow_run`
- Inclui argumento `run_config` ao usar a task `create_flow_run`, usando sempre como referência a `run_config` do flow principal
- 
# Changelog - projeto_subsidio_sppo

## [1.0.1] - 2024-06-03

### Alterado

- Altera constante `SUBSIDIO_SPPO_CODE_OWNERS`
