### PR TITLE
Bilhetagem - Exclui servicos nos pipelines de materialização

### DIFF
--- a/pipelines/rj_smtr/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - br_rj_riodejaneiro_bilhetagem
+
+## [1.0.0] - 2024-05-17
+
+### Alterado
+
+- Adiciona +servicos no exclude geral dos pipelines de materialização da bilhetagem (https://github.com/prefeitura-rio/pipelines/pull/685)

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_bilhetagem/CHANGELOG.md
@@ -5,3 +5,8 @@
 ### Alterado
 
 - Adiciona +servicos no exclude geral dos pipelines de materialização da bilhetagem (https://github.com/prefeitura-rio/pipelines/pull/685)
+
+### Corrigido
+
+- Corrige parametros do flow `bilhetagem_validacao_jae` (https://github.com/prefeitura-rio/pipelines/pull/685)
+- Adiciona tabelas de validação no exclude do flow `bilhetagem_materializacao_gps_validador` (https://github.com/prefeitura-rio/pipelines/pull/685)

--- a/pipelines/rj_smtr/br_rj_riodejaneiro_bilhetagem/flows.py
+++ b/pipelines/rj_smtr/br_rj_riodejaneiro_bilhetagem/flows.py
@@ -319,7 +319,7 @@ bilhetagem_validacao_jae.run_config = KubernetesRun(
 
 bilhetagem_validacao_jae = set_default_parameters(
     flow=bilhetagem_validacao_jae,
-    default_parameters=constants.BILHETAGEM_MATERIALIZACAO_GPS_VALIDADOR_GENERAL_PARAMS.value,
+    default_parameters=constants.BILHETAGEM_MATERIALIZACAO_VALIDACAO_JAE_PARAMS.value,
 )
 
 bilhetagem_validacao_jae.schedule = every_day_hour_seven

--- a/pipelines/rj_smtr/constants.py
+++ b/pipelines/rj_smtr/constants.py
@@ -1258,7 +1258,7 @@ class constants(Enum):  # pylint: disable=c0103
         "dataset_id": BILHETAGEM_DATASET_ID,
         "upstream": True,
         "downstream": True,
-        "exclude": BILHETAGEM_EXCLUDE,
+        "exclude": f"{BILHETAGEM_EXCLUDE} veiculo_validacao veiculo_indicadores_dia",
         "dbt_vars": {
             "date_range": {
                 "table_run_datetime_column_name": "datetime_captura",

--- a/pipelines/rj_smtr/constants.py
+++ b/pipelines/rj_smtr/constants.py
@@ -1197,7 +1197,7 @@ class constants(Enum):  # pylint: disable=c0103
         },
     ]
 
-    BILHETAGEM_EXCLUDE = "+operadoras +consorcios"
+    BILHETAGEM_EXCLUDE = "+operadoras +consorcios +servicos"
 
     BILHETAGEM_JAE_DASHBOARD_DATASET_ID = "dashboard_bilhetagem_jae"
 


### PR DESCRIPTION
# ChangeLog

### Alterado
adiciona `+servicos` no exclude geral dos pipelines de materialização da bilhetagem

### Corrigido

- Corrige parametros do flow `bilhetagem_validacao_jae`
- Adiciona tabelas de validação no exclude do flow `bilhetagem_materializacao_gps_validador`